### PR TITLE
[11팀 이동아] Chapter 3-1 프런트엔드 테스트 코드 

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -8,7 +8,7 @@
   "jsxSingleQuote": false,
   "trailingComma": "es5",
   "arrowParens": "always",
-  "endOfLine": "lf",
+  "endOfLine": "crlf",
   "bracketSpacing": true,
   "jsxBracketSameLine": false,
   "requirePragma": false,

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "express": "^4.19.2",
     "framer-motion": "^11.3.2",
     "msw": "^2.3.1",
+    "overlay-kit": "^1.4.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
@@ -46,10 +47,10 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-storybook": "^0.6.12",
     "eslint-plugin-vitest": "^0.2.6",
-    "vite-plugin-eslint": "^1.8.1",
     "jsdom": "^25.0.1",
     "typescript": "^5.2.2",
     "vite": "^5.3.1",
+    "vite-plugin-eslint": "^1.8.1",
     "vitest": "^2.0.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       msw:
         specifier: ^2.3.1
         version: 2.5.1(@types/node@22.8.1)(typescript@5.6.3)
+      overlay-kit:
+        specifier: ^1.4.1
+        version: 1.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -62,7 +65,7 @@ importers:
         version: 3.7.1(vite@5.4.10(@types/node@22.8.1))
       '@vitest/coverage-v8':
         specifier: ^2.0.3
-        version: 2.1.3(vitest@2.1.3(@types/node@22.8.1)(@vitest/ui@1.6.0)(jsdom@25.0.1)(msw@2.5.1(@types/node@22.8.1)(typescript@5.6.3)))
+        version: 2.1.3(vitest@2.1.3)
       '@vitest/ui':
         specifier: ^1.6.0
         version: 1.6.0(vitest@2.1.3)
@@ -95,7 +98,7 @@ importers:
         version: 0.6.15(eslint@8.57.1)(typescript@5.6.3)
       eslint-plugin-vitest:
         specifier: ^0.2.6
-        version: 0.2.8(eslint@8.57.1)(typescript@5.6.3)(vite@5.4.10(@types/node@22.8.1))(vitest@2.1.3(@types/node@22.8.1)(@vitest/ui@1.6.0)(jsdom@25.0.1)(msw@2.5.1(@types/node@22.8.1)(typescript@5.6.3)))
+        version: 0.2.8(eslint@8.57.1)(typescript@5.6.3)(vite@5.4.10(@types/node@22.8.1))(vitest@2.1.3)
       jsdom:
         specifier: ^25.0.1
         version: 25.0.1
@@ -2134,6 +2137,12 @@ packages:
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
 
+  overlay-kit@1.4.1:
+    resolution: {integrity: sha512-BSzpilw1pM1j6/r04Qwc/FHnWe0Hio0qbhdepJuihx352q+n/FPUAr297MqjKanniH722VDPxFdq7JFjErIXdQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
@@ -2737,6 +2746,11 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  use-sync-external-store@1.2.2:
+    resolution: {integrity: sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
 
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
@@ -3714,7 +3728,7 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitest/coverage-v8@2.1.3(vitest@2.1.3(@types/node@22.8.1)(@vitest/ui@1.6.0)(jsdom@25.0.1)(msw@2.5.1(@types/node@22.8.1)(typescript@5.6.3)))':
+  '@vitest/coverage-v8@2.1.3(vitest@2.1.3)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -4404,7 +4418,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-vitest@0.2.8(eslint@8.57.1)(typescript@5.6.3)(vite@5.4.10(@types/node@22.8.1))(vitest@2.1.3(@types/node@22.8.1)(@vitest/ui@1.6.0)(jsdom@25.0.1)(msw@2.5.1(@types/node@22.8.1)(typescript@5.6.3))):
+  eslint-plugin-vitest@0.2.8(eslint@8.57.1)(typescript@5.6.3)(vite@5.4.10(@types/node@22.8.1))(vitest@2.1.3):
     dependencies:
       '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.6.3)
       eslint: 8.57.1
@@ -5187,6 +5201,12 @@ snapshots:
 
   outvariant@1.4.3: {}
 
+  overlay-kit@1.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      use-sync-external-store: 1.2.2(react@18.3.1)
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
@@ -5811,6 +5831,10 @@ snapshots:
       tslib: 2.8.0
     optionalDependencies:
       '@types/react': 18.3.12
+
+  use-sync-external-store@1.2.2(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   utils-merge@1.0.1: {}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,21 +1,4 @@
-import { BellIcon, ChevronLeftIcon, ChevronRightIcon, DeleteIcon } from '@chakra-ui/icons';
-import {
-  Alert,
-  AlertIcon,
-  AlertTitle,
-  Box,
-  CloseButton,
-  Flex,
-  FormControl,
-  FormLabel,
-  Heading,
-  HStack,
-  IconButton,
-  Input,
-  Select,
-  Text,
-  VStack,
-} from '@chakra-ui/react';
+import { Box, Flex, FormControl, FormLabel, Heading, Input, Text, VStack } from '@chakra-ui/react';
 
 import { EventCard } from './components/EventCard.tsx';
 import { EventHandleForm } from './components/EventHandleForm.tsx';
@@ -24,6 +7,8 @@ import { MonthView } from './components/MonthView.tsx';
 import { NotificationAlert } from './components/NotificationAlert.tsx';
 import { WeekView } from './components/WeekView.tsx';
 import { useCalendarView } from './hooks/useCalendarView.ts';
+import { useEditingEvent } from './hooks/useEditingEvent.ts';
+import { useEventForm } from './hooks/useEventForm.ts';
 import { useEventOperations } from './hooks/useEventOperations.ts';
 import { useNotifications } from './hooks/useNotifications.ts';
 import { useSearch } from './hooks/useSearch.ts';
@@ -37,10 +22,14 @@ const notificationOptions = [
 ];
 
 function App() {
-  const { events, saveEvent, deleteEvent } = useEventOperations(Boolean(false));
-  // const { events, saveEvent, deleteEvent } = useEventOperations(Boolean(editingEvent), () =>
-  //   setEditingEvent(null)
-  // );
+  const eventFormState = useEventForm();
+  const { editingEvent, editEvent, setEditingEvent } = useEditingEvent({
+    setEventForm: eventFormState.setEventForm,
+    setIsRepeating: eventFormState.setIsRepeating,
+  });
+  const { events, saveEvent, deleteEvent } = useEventOperations(Boolean(editingEvent), () =>
+    setEditingEvent(null)
+  );
 
   const { notifications, notifiedEvents, setNotifications } = useNotifications(events);
   const { view, setView, currentDate, holidays, navigate } = useCalendarView();
@@ -49,7 +38,12 @@ function App() {
   return (
     <Box w="full" h="100vh" m="auto" p={5}>
       <Flex gap={6} h="full">
-        <EventHandleForm events={events} saveEvent={saveEvent} />
+        <EventHandleForm
+          events={events}
+          saveEvent={saveEvent}
+          editingEvent={editingEvent}
+          eventFormState={eventFormState}
+        />
 
         <VStack flex={1} spacing={5} align="stretch">
           <Heading>일정 보기</Heading>
@@ -91,6 +85,8 @@ function App() {
                 event={event}
                 notifiedEvents={notifiedEvents}
                 notificationOptions={notificationOptions}
+                editEvent={editEvent}
+                deleteEvent={deleteEvent}
                 key={event.id}
               />
             ))

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,23 +1,9 @@
-import {
-  BellIcon,
-  ChevronLeftIcon,
-  ChevronRightIcon,
-  DeleteIcon,
-  EditIcon,
-} from '@chakra-ui/icons';
+import { BellIcon, ChevronLeftIcon, ChevronRightIcon, DeleteIcon } from '@chakra-ui/icons';
 import {
   Alert,
-  AlertDialog,
-  AlertDialogBody,
-  AlertDialogContent,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogOverlay,
   AlertIcon,
   AlertTitle,
   Box,
-  Button,
-  Checkbox,
   CloseButton,
   Flex,
   FormControl,
@@ -27,39 +13,17 @@ import {
   IconButton,
   Input,
   Select,
-  Table,
-  Tbody,
-  Td,
   Text,
-  Th,
-  Thead,
-  Tooltip,
-  Tr,
-  useToast,
   VStack,
 } from '@chakra-ui/react';
-import { useRef, useState } from 'react';
 
+import { EventHandleForm } from './components/EventHandleForm.tsx';
+import { MonthView } from './components/MonthView.tsx';
+import { WeekView } from './components/WeekView.tsx';
 import { useCalendarView } from './hooks/useCalendarView.ts';
-import { useEventForm } from './hooks/useEventForm.ts';
 import { useEventOperations } from './hooks/useEventOperations.ts';
 import { useNotifications } from './hooks/useNotifications.ts';
 import { useSearch } from './hooks/useSearch.ts';
-import { Event, EventForm, RepeatType } from './types';
-import {
-  formatDate,
-  formatMonth,
-  formatWeek,
-  getEventsForDay,
-  getWeekDates,
-  getWeeksAtMonth,
-} from './utils/dateUtils';
-import { findOverlappingEvents } from './utils/eventOverlap';
-import { getTimeErrorMessage } from './utils/timeValidation';
-
-const categories = ['업무', '개인', '가족', '기타'];
-
-const weekDays = ['일', '월', '화', '수', '목', '금', '토'];
 
 const notificationOptions = [
   { value: 1, label: '1분 전' },
@@ -70,39 +34,6 @@ const notificationOptions = [
 ];
 
 function App() {
-  const {
-    title,
-    setTitle,
-    date,
-    setDate,
-    startTime,
-    endTime,
-    description,
-    setDescription,
-    location,
-    setLocation,
-    category,
-    setCategory,
-    isRepeating,
-    setIsRepeating,
-    repeatType,
-    setRepeatType,
-    repeatInterval,
-    setRepeatInterval,
-    repeatEndDate,
-    setRepeatEndDate,
-    notificationTime,
-    setNotificationTime,
-    startTimeError,
-    endTimeError,
-    editingEvent,
-    setEditingEvent,
-    handleStartTimeChange,
-    handleEndTimeChange,
-    resetForm,
-    editEvent,
-  } = useEventForm();
-
   const { events, saveEvent, deleteEvent } = useEventOperations(Boolean(editingEvent), () =>
     setEditingEvent(null)
   );
@@ -111,312 +42,10 @@ function App() {
   const { view, setView, currentDate, holidays, navigate } = useCalendarView();
   const { searchTerm, filteredEvents, setSearchTerm } = useSearch(events, currentDate, view);
 
-  const [isOverlapDialogOpen, setIsOverlapDialogOpen] = useState(false);
-  const [overlappingEvents, setOverlappingEvents] = useState<Event[]>([]);
-  const cancelRef = useRef<HTMLButtonElement>(null);
-
-  const toast = useToast();
-
-  const addOrUpdateEvent = async () => {
-    if (!title || !date || !startTime || !endTime) {
-      toast({
-        title: '필수 정보를 모두 입력해주세요.',
-        status: 'error',
-        duration: 3000,
-        isClosable: true,
-      });
-      return;
-    }
-
-    if (startTimeError || endTimeError) {
-      toast({
-        title: '시간 설정을 확인해주세요.',
-        status: 'error',
-        duration: 3000,
-        isClosable: true,
-      });
-      return;
-    }
-
-    const eventData: Event | EventForm = {
-      id: editingEvent ? editingEvent.id : undefined,
-      title,
-      date,
-      startTime,
-      endTime,
-      description,
-      location,
-      category,
-      repeat: {
-        type: isRepeating ? repeatType : 'none',
-        interval: repeatInterval,
-        endDate: repeatEndDate || undefined,
-      },
-      notificationTime,
-    };
-
-    const overlapping = findOverlappingEvents(eventData, events);
-    if (overlapping.length > 0) {
-      setOverlappingEvents(overlapping);
-      setIsOverlapDialogOpen(true);
-    } else {
-      await saveEvent(eventData);
-      resetForm();
-    }
-  };
-
-  const renderWeekView = () => {
-    const weekDates = getWeekDates(currentDate);
-    return (
-      <VStack data-testid="week-view" align="stretch" w="full" spacing={4}>
-        <Heading size="md">{formatWeek(currentDate)}</Heading>
-        <Table variant="simple" w="full">
-          <Thead>
-            <Tr>
-              {weekDays.map((day) => (
-                <Th key={day} width="14.28%">
-                  {day}
-                </Th>
-              ))}
-            </Tr>
-          </Thead>
-          <Tbody>
-            <Tr>
-              {weekDates.map((date) => (
-                <Td key={date.toISOString()} height="100px" verticalAlign="top" width="14.28%">
-                  <Text fontWeight="bold">{date.getDate()}</Text>
-                  {filteredEvents
-                    .filter((event) => new Date(event.date).toDateString() === date.toDateString())
-                    .map((event) => {
-                      const isNotified = notifiedEvents.includes(event.id);
-                      return (
-                        <Box
-                          key={event.id}
-                          p={1}
-                          my={1}
-                          bg={isNotified ? 'red.100' : 'gray.100'}
-                          borderRadius="md"
-                          fontWeight={isNotified ? 'bold' : 'normal'}
-                          color={isNotified ? 'red.500' : 'inherit'}
-                        >
-                          <HStack spacing={1}>
-                            {isNotified && <BellIcon />}
-                            <Text fontSize="sm" noOfLines={1}>
-                              {event.title}
-                            </Text>
-                          </HStack>
-                        </Box>
-                      );
-                    })}
-                </Td>
-              ))}
-            </Tr>
-          </Tbody>
-        </Table>
-      </VStack>
-    );
-  };
-
-  const renderMonthView = () => {
-    const weeks = getWeeksAtMonth(currentDate);
-
-    return (
-      <VStack data-testid="month-view" align="stretch" w="full" spacing={4}>
-        <Heading size="md">{formatMonth(currentDate)}</Heading>
-        <Table variant="simple" w="full">
-          <Thead>
-            <Tr>
-              {weekDays.map((day) => (
-                <Th key={day} width="14.28%">
-                  {day}
-                </Th>
-              ))}
-            </Tr>
-          </Thead>
-          <Tbody>
-            {weeks.map((week, weekIndex) => (
-              <Tr key={weekIndex}>
-                {week.map((day, dayIndex) => {
-                  const dateString = day ? formatDate(currentDate, day) : '';
-                  const holiday = holidays[dateString];
-
-                  return (
-                    <Td
-                      key={dayIndex}
-                      height="100px"
-                      verticalAlign="top"
-                      width="14.28%"
-                      position="relative"
-                    >
-                      {day && (
-                        <>
-                          <Text fontWeight="bold">{day}</Text>
-                          {holiday && (
-                            <Text color="red.500" fontSize="sm">
-                              {holiday}
-                            </Text>
-                          )}
-                          {getEventsForDay(filteredEvents, day).map((event) => {
-                            const isNotified = notifiedEvents.includes(event.id);
-                            return (
-                              <Box
-                                key={event.id}
-                                p={1}
-                                my={1}
-                                bg={isNotified ? 'red.100' : 'gray.100'}
-                                borderRadius="md"
-                                fontWeight={isNotified ? 'bold' : 'normal'}
-                                color={isNotified ? 'red.500' : 'inherit'}
-                              >
-                                <HStack spacing={1}>
-                                  {isNotified && <BellIcon />}
-                                  <Text fontSize="sm" noOfLines={1}>
-                                    {event.title}
-                                  </Text>
-                                </HStack>
-                              </Box>
-                            );
-                          })}
-                        </>
-                      )}
-                    </Td>
-                  );
-                })}
-              </Tr>
-            ))}
-          </Tbody>
-        </Table>
-      </VStack>
-    );
-  };
-
   return (
     <Box w="full" h="100vh" m="auto" p={5}>
       <Flex gap={6} h="full">
-        <VStack w="400px" spacing={5} align="stretch">
-          <Heading>{editingEvent ? '일정 수정' : '일정 추가'}</Heading>
-
-          <FormControl>
-            <FormLabel>제목</FormLabel>
-            <Input value={title} onChange={(e) => setTitle(e.target.value)} />
-          </FormControl>
-
-          <FormControl>
-            <FormLabel>날짜</FormLabel>
-            <Input type="date" value={date} onChange={(e) => setDate(e.target.value)} />
-          </FormControl>
-
-          <HStack width="100%">
-            <FormControl>
-              <FormLabel>시작 시간</FormLabel>
-              <Tooltip label={startTimeError} isOpen={!!startTimeError} placement="top">
-                <Input
-                  type="time"
-                  value={startTime}
-                  onChange={handleStartTimeChange}
-                  onBlur={() => getTimeErrorMessage(startTime, endTime)}
-                  isInvalid={!!startTimeError}
-                />
-              </Tooltip>
-            </FormControl>
-            <FormControl>
-              <FormLabel>종료 시간</FormLabel>
-              <Tooltip label={endTimeError} isOpen={!!endTimeError} placement="top">
-                <Input
-                  type="time"
-                  value={endTime}
-                  onChange={handleEndTimeChange}
-                  onBlur={() => getTimeErrorMessage(startTime, endTime)}
-                  isInvalid={!!endTimeError}
-                />
-              </Tooltip>
-            </FormControl>
-          </HStack>
-
-          <FormControl>
-            <FormLabel>설명</FormLabel>
-            <Input value={description} onChange={(e) => setDescription(e.target.value)} />
-          </FormControl>
-
-          <FormControl>
-            <FormLabel>위치</FormLabel>
-            <Input value={location} onChange={(e) => setLocation(e.target.value)} />
-          </FormControl>
-
-          <FormControl>
-            <FormLabel>카테고리</FormLabel>
-            <Select value={category} onChange={(e) => setCategory(e.target.value)}>
-              <option value="">카테고리 선택</option>
-              {categories.map((cat) => (
-                <option key={cat} value={cat}>
-                  {cat}
-                </option>
-              ))}
-            </Select>
-          </FormControl>
-
-          <FormControl>
-            <FormLabel>반복 설정</FormLabel>
-            <Checkbox isChecked={isRepeating} onChange={(e) => setIsRepeating(e.target.checked)}>
-              반복 일정
-            </Checkbox>
-          </FormControl>
-
-          <FormControl>
-            <FormLabel>알림 설정</FormLabel>
-            <Select
-              value={notificationTime}
-              onChange={(e) => setNotificationTime(Number(e.target.value))}
-            >
-              {notificationOptions.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </Select>
-          </FormControl>
-
-          {isRepeating && (
-            <VStack width="100%">
-              <FormControl>
-                <FormLabel>반복 유형</FormLabel>
-                <Select
-                  value={repeatType}
-                  onChange={(e) => setRepeatType(e.target.value as RepeatType)}
-                >
-                  <option value="daily">매일</option>
-                  <option value="weekly">매주</option>
-                  <option value="monthly">매월</option>
-                  <option value="yearly">매년</option>
-                </Select>
-              </FormControl>
-              <HStack width="100%">
-                <FormControl>
-                  <FormLabel>반복 간격</FormLabel>
-                  <Input
-                    type="number"
-                    value={repeatInterval}
-                    onChange={(e) => setRepeatInterval(Number(e.target.value))}
-                    min={1}
-                  />
-                </FormControl>
-                <FormControl>
-                  <FormLabel>반복 종료일</FormLabel>
-                  <Input
-                    type="date"
-                    value={repeatEndDate}
-                    onChange={(e) => setRepeatEndDate(e.target.value)}
-                  />
-                </FormControl>
-              </HStack>
-            </VStack>
-          )}
-
-          <Button data-testid="event-submit-button" onClick={addOrUpdateEvent} colorScheme="blue">
-            {editingEvent ? '일정 수정' : '일정 추가'}
-          </Button>
-        </VStack>
-
+        <EventHandleForm />
         <VStack flex={1} spacing={5} align="stretch">
           <Heading>일정 보기</Heading>
 
@@ -441,8 +70,21 @@ function App() {
             />
           </HStack>
 
-          {view === 'week' && renderWeekView()}
-          {view === 'month' && renderMonthView()}
+          {view === 'week' && (
+            <WeekView
+              currentDate={currentDate}
+              filteredEvents={filteredEvents}
+              notifiedEvents={notifiedEvents}
+            />
+          )}
+          {view === 'month' && (
+            <MonthView
+              currentDate={currentDate}
+              filteredEvents={filteredEvents}
+              holidays={holidays}
+              notifiedEvents={notifiedEvents}
+            />
+          )}
         </VStack>
 
         <VStack data-testid="event-list" w="500px" h="full" overflowY="auto">
@@ -499,11 +141,11 @@ function App() {
                     </Text>
                   </VStack>
                   <HStack>
-                    <IconButton
+                    {/* <IconButton
                       aria-label="Edit event"
                       icon={<EditIcon />}
                       onClick={() => editEvent(event)}
-                    />
+                    /> */}
                     <IconButton
                       aria-label="Delete event"
                       icon={<DeleteIcon />}
@@ -517,7 +159,7 @@ function App() {
         </VStack>
       </Flex>
 
-      <AlertDialog
+      {/* <AlertDialog
         isOpen={isOverlapDialogOpen}
         leastDestructiveRef={cancelRef}
         onClose={() => setIsOverlapDialogOpen(false)}
@@ -570,7 +212,7 @@ function App() {
             </AlertDialogFooter>
           </AlertDialogContent>
         </AlertDialogOverlay>
-      </AlertDialog>
+      </AlertDialog> */}
 
       {notifications.length > 0 && (
         <VStack position="fixed" top={4} right={4} spacing={2} align="flex-end">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,8 +17,11 @@ import {
   VStack,
 } from '@chakra-ui/react';
 
+import { EventCard } from './components/EventCard.tsx';
 import { EventHandleForm } from './components/EventHandleForm.tsx';
+import { EventHandleNavigate } from './components/EventHandleNavigate.tsx';
 import { MonthView } from './components/MonthView.tsx';
+import { NotificationAlert } from './components/NotificationAlert.tsx';
 import { WeekView } from './components/WeekView.tsx';
 import { useCalendarView } from './hooks/useCalendarView.ts';
 import { useEventOperations } from './hooks/useEventOperations.ts';
@@ -34,9 +37,10 @@ const notificationOptions = [
 ];
 
 function App() {
-  const { events, saveEvent, deleteEvent } = useEventOperations(Boolean(editingEvent), () =>
-    setEditingEvent(null)
-  );
+  const { events, saveEvent, deleteEvent } = useEventOperations(Boolean(false));
+  // const { events, saveEvent, deleteEvent } = useEventOperations(Boolean(editingEvent), () =>
+  //   setEditingEvent(null)
+  // );
 
   const { notifications, notifiedEvents, setNotifications } = useNotifications(events);
   const { view, setView, currentDate, holidays, navigate } = useCalendarView();
@@ -45,30 +49,12 @@ function App() {
   return (
     <Box w="full" h="100vh" m="auto" p={5}>
       <Flex gap={6} h="full">
-        <EventHandleForm />
+        <EventHandleForm events={events} saveEvent={saveEvent} />
+
         <VStack flex={1} spacing={5} align="stretch">
           <Heading>일정 보기</Heading>
 
-          <HStack mx="auto" justifyContent="space-between">
-            <IconButton
-              aria-label="Previous"
-              icon={<ChevronLeftIcon />}
-              onClick={() => navigate('prev')}
-            />
-            <Select
-              aria-label="view"
-              value={view}
-              onChange={(e) => setView(e.target.value as 'week' | 'month')}
-            >
-              <option value="week">Week</option>
-              <option value="month">Month</option>
-            </Select>
-            <IconButton
-              aria-label="Next"
-              icon={<ChevronRightIcon />}
-              onClick={() => navigate('next')}
-            />
-          </HStack>
+          <EventHandleNavigate view={view} setView={setView} navigate={navigate} />
 
           {view === 'week' && (
             <WeekView
@@ -101,131 +87,26 @@ function App() {
             <Text>검색 결과가 없습니다.</Text>
           ) : (
             filteredEvents.map((event) => (
-              <Box key={event.id} borderWidth={1} borderRadius="lg" p={3} width="100%">
-                <HStack justifyContent="space-between">
-                  <VStack align="start">
-                    <HStack>
-                      {notifiedEvents.includes(event.id) && <BellIcon color="red.500" />}
-                      <Text
-                        fontWeight={notifiedEvents.includes(event.id) ? 'bold' : 'normal'}
-                        color={notifiedEvents.includes(event.id) ? 'red.500' : 'inherit'}
-                      >
-                        {event.title}
-                      </Text>
-                    </HStack>
-                    <Text>{event.date}</Text>
-                    <Text>
-                      {event.startTime} - {event.endTime}
-                    </Text>
-                    <Text>{event.description}</Text>
-                    <Text>{event.location}</Text>
-                    <Text>카테고리: {event.category}</Text>
-                    {event.repeat.type !== 'none' && (
-                      <Text>
-                        반복: {event.repeat.interval}
-                        {event.repeat.type === 'daily' && '일'}
-                        {event.repeat.type === 'weekly' && '주'}
-                        {event.repeat.type === 'monthly' && '월'}
-                        {event.repeat.type === 'yearly' && '년'}
-                        마다
-                        {event.repeat.endDate && ` (종료: ${event.repeat.endDate})`}
-                      </Text>
-                    )}
-                    <Text>
-                      알림:{' '}
-                      {
-                        notificationOptions.find(
-                          (option) => option.value === event.notificationTime
-                        )?.label
-                      }
-                    </Text>
-                  </VStack>
-                  <HStack>
-                    {/* <IconButton
-                      aria-label="Edit event"
-                      icon={<EditIcon />}
-                      onClick={() => editEvent(event)}
-                    /> */}
-                    <IconButton
-                      aria-label="Delete event"
-                      icon={<DeleteIcon />}
-                      onClick={() => deleteEvent(event.id)}
-                    />
-                  </HStack>
-                </HStack>
-              </Box>
+              <EventCard
+                event={event}
+                notifiedEvents={notifiedEvents}
+                notificationOptions={notificationOptions}
+                key={event.id}
+              />
             ))
           )}
         </VStack>
       </Flex>
 
-      {/* <AlertDialog
-        isOpen={isOverlapDialogOpen}
-        leastDestructiveRef={cancelRef}
-        onClose={() => setIsOverlapDialogOpen(false)}
-      >
-        <AlertDialogOverlay>
-          <AlertDialogContent>
-            <AlertDialogHeader fontSize="lg" fontWeight="bold">
-              일정 겹침 경고
-            </AlertDialogHeader>
-
-            <AlertDialogBody>
-              다음 일정과 겹칩니다:
-              {overlappingEvents.map((event) => (
-                <Text key={event.id}>
-                  {event.title} ({event.date} {event.startTime}-{event.endTime})
-                </Text>
-              ))}
-              계속 진행하시겠습니까?
-            </AlertDialogBody>
-
-            <AlertDialogFooter>
-              <Button ref={cancelRef} onClick={() => setIsOverlapDialogOpen(false)}>
-                취소
-              </Button>
-              <Button
-                colorScheme="red"
-                onClick={() => {
-                  setIsOverlapDialogOpen(false);
-                  saveEvent({
-                    id: editingEvent ? editingEvent.id : undefined,
-                    title,
-                    date,
-                    startTime,
-                    endTime,
-                    description,
-                    location,
-                    category,
-                    repeat: {
-                      type: isRepeating ? repeatType : 'none',
-                      interval: repeatInterval,
-                      endDate: repeatEndDate || undefined,
-                    },
-                    notificationTime,
-                  });
-                }}
-                ml={3}
-              >
-                계속 진행
-              </Button>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialogOverlay>
-      </AlertDialog> */}
-
       {notifications.length > 0 && (
         <VStack position="fixed" top={4} right={4} spacing={2} align="flex-end">
           {notifications.map((notification, index) => (
-            <Alert key={index} status="info" variant="solid" width="auto">
-              <AlertIcon />
-              <Box flex="1">
-                <AlertTitle fontSize="sm">{notification.message}</AlertTitle>
-              </Box>
-              <CloseButton
-                onClick={() => setNotifications((prev) => prev.filter((_, i) => i !== index))}
-              />
-            </Alert>
+            <NotificationAlert
+              notification={notification}
+              setNotifications={setNotifications}
+              index={index}
+              key={notification.id}
+            />
           ))}
         </VStack>
       )}

--- a/src/__mocks__/handlers.ts
+++ b/src/__mocks__/handlers.ts
@@ -5,12 +5,58 @@ import { events } from './response/events.json' assert { type: 'json' };
 
 // ! HARD
 // ! 각 응답에 대한 MSW 핸들러를 작성해주세요. GET 요청은 이미 작성되어 있는 events json을 활용해주세요.
+const eventsState = {
+  event: [...events],
+};
+
 export const handlers = [
-  http.get('/api/events', () => {}),
+  http.get('/api/events', () => {
+    return HttpResponse.json({ events: eventsState.event });
+  }),
 
-  http.post('/api/events', async ({ request }) => {}),
+  http.post('/api/events', async ({ request }) => {
+    const newEvent: Event = (await request.json()) as Event;
 
-  http.put('/api/events/:id', async () => {}),
+    if (!newEvent) {
+      return HttpResponse.json(null, { status: 404 });
+    }
 
-  http.delete('/api/events/:id', ({ params }) => {}),
+    eventsState.event = [...eventsState.event, newEvent];
+
+    return HttpResponse.json(newEvent, { status: 201 });
+  }),
+
+  http.put('/api/events/:id', async ({ params, request }) => {
+    const { id } = params;
+
+    const updateEvent = events.find((event) => event.id === id);
+    if (!updateEvent) {
+      return HttpResponse.json(null, { status: 404 });
+    }
+
+    const updatedEventData = (await request.json()) as Event;
+
+    if (!updatedEventData) {
+      return HttpResponse.json(null, { status: 404 });
+    }
+
+    eventsState.event = events.map((event) => {
+      return event.id === id ? updatedEventData : event;
+    });
+
+    return HttpResponse.json(updatedEventData);
+  }),
+
+  http.delete('/api/events/:id', ({ params }) => {
+    const { id } = params;
+
+    const deletedEvent = events.find((event) => event.id === id);
+    if (!deletedEvent) {
+      return new HttpResponse(null, { status: 404 });
+    }
+
+    eventsState.event = eventsState.event.filter((event) => event.id !== id);
+
+    return HttpResponse.json(deletedEvent);
+  }),
 ];

--- a/src/__mocks__/handlersUtils.ts
+++ b/src/__mocks__/handlersUtils.ts
@@ -1,10 +1,99 @@
+import { http, HttpResponse } from 'msw';
+
 import { Event } from '../types';
-
+import { events } from './response/events.json' assert { type: 'json' };
 // ! Hard
-// ! 이벤트는 생성, 수정 되면 fetch를 다시 해 상태를 업데이트 합니다. 이를 위한 제어가 필요할 것 같은데요. 어떻게 작성해야 테스트가 병렬로 돌아도 안정적이게 동작할까요?
-// ! 아래 이름을 사용하지 않아도 되니, 독립적이게 테스트를 구동할 수 있는 방법을 찾아보세요. 그리고 이 로직을 PR에 설명해주세요.
-export const setupMockHandlerCreation = (initEvents = [] as Event[]) => {};
+{
+  /* 
+  ! 이벤트는 생성, 수정 되면 fetch를 다시 해 상태를 업데이트 합니다.
+  ! 이를 위한 제어가 필요할 것 같은데요. 어떻게 작성해야 테스트가 병렬로 돌아도 안정적이게 동작할까요 ?
+  */
+}
+{
+  /*  
+  ! 아래 이름을 사용하지 않아도 되니, 독립적이게 테스트를 구동할 수 있는 방법을 찾아보세요. 
+  ! 그리고 이 로직을 PR에 설명해주세요.
+   */
+}
 
-export const setupMockHandlerUpdating = () => {};
+export const setupHandler = () => {
+  let eventsState = [...events];
 
-export const setupMockHandlerDeletion = () => {};
+  function resetInitState() {
+    eventsState = [...events];
+  }
+
+  const setupMockHandlerRead = () => {
+    const httpGetMethod = http.get('/api/events', () => {
+      return HttpResponse.json({ events: eventsState });
+    });
+
+    return httpGetMethod;
+  };
+
+  const setupMockHandlerCreation = () => {
+    const httpPostMethod = http.post('/api/events', async ({ request }) => {
+      const newEvent: Event = (await request.json()) as Event;
+
+      if (!newEvent) {
+        return HttpResponse.json(null, { status: 404 });
+      }
+
+      eventsState = [...eventsState, newEvent];
+
+      return HttpResponse.json(newEvent, { status: 201 });
+    });
+
+    return httpPostMethod;
+  };
+
+  const setupMockHandlerUpdating = () => {
+    const httpPutMethod = http.put('/api/events/:id', async ({ params, request }) => {
+      const { id } = params;
+
+      const updateEvent = events.find((event) => event.id === id);
+      if (!updateEvent) {
+        return HttpResponse.json(null, { status: 404 });
+      }
+
+      const updatedEventData = (await request.json()) as Event;
+
+      if (!updatedEventData) {
+        return HttpResponse.json(null, { status: 404 });
+      }
+
+      eventsState = eventsState.map((event) => {
+        return event.id === id ? updatedEventData : event;
+      });
+
+      return HttpResponse.json(updatedEventData);
+    });
+
+    return httpPutMethod;
+  };
+
+  const setupMockHandlerDeletion = () => {
+    const httpDeleteMethod = http.delete('/api/events/:id', ({ params }) => {
+      const { id } = params;
+
+      const deletedEvent = events.find((event) => event.id === id);
+      if (!deletedEvent) {
+        return new HttpResponse(null, { status: 404 });
+      }
+
+      eventsState = eventsState.filter((event) => event.id !== id);
+
+      return HttpResponse.json(deletedEvent);
+    });
+
+    return httpDeleteMethod;
+  };
+
+  return {
+    resetInitState,
+    setupMockHandlerRead,
+    setupMockHandlerCreation,
+    setupMockHandlerUpdating,
+    setupMockHandlerDeletion,
+  };
+};

--- a/src/__mocks__/handlersUtils.ts
+++ b/src/__mocks__/handlersUtils.ts
@@ -35,7 +35,7 @@ export const setupHandler = () => {
     const httpPostMethod = http.post('/api/events', async ({ request }) => {
       const newEvent: Event = (await request.json()) as Event;
 
-      newEvent.id = crypto.randomUUID();
+      newEvent.id = String(eventsState.length + 1);
 
       if (!newEvent) {
         return HttpResponse.json(null, { status: 404 });

--- a/src/__mocks__/handlersUtils.ts
+++ b/src/__mocks__/handlersUtils.ts
@@ -35,6 +35,8 @@ export const setupHandler = () => {
     const httpPostMethod = http.post('/api/events', async ({ request }) => {
       const newEvent: Event = (await request.json()) as Event;
 
+      newEvent.id = crypto.randomUUID();
+
       if (!newEvent) {
         return HttpResponse.json(null, { status: 404 });
       }
@@ -51,7 +53,7 @@ export const setupHandler = () => {
     const httpPutMethod = http.put('/api/events/:id', async ({ params, request }) => {
       const { id } = params;
 
-      const updateEvent = events.find((event) => event.id === id);
+      const updateEvent = eventsState.find((event) => event.id === id);
       if (!updateEvent) {
         return HttpResponse.json(null, { status: 404 });
       }

--- a/src/__tests__/hooks/easy.useCalendarView.spec.ts
+++ b/src/__tests__/hooks/easy.useCalendarView.spec.ts
@@ -4,21 +4,74 @@ import { useCalendarView } from '../../hooks/useCalendarView.ts';
 import { assertDate } from '../utils.ts';
 
 describe('초기 상태', () => {
-  it('view는 "month"이어야 한다', () => {});
+  const mockDate = new Date('2024-10-01');
+  vi.setSystemTime(mockDate);
 
-  it('currentDate는 오늘 날짜인 "2024-10-01"이어야 한다', () => {});
+  it('view는 "month"이어야 한다', () => {
+    const { result } = renderHook(() => useCalendarView());
+    const { view } = result.current;
 
-  it('holidays는 10월 휴일인 개천절, 한글날이 지정되어 있어야 한다', () => {});
+    expect(view).toBe('month');
+  });
+
+  it('currentDate는 오늘 날짜인 "2024-10-01"이어야 한다', () => {
+    const { result } = renderHook(() => useCalendarView());
+
+    assertDate(result.current.currentDate, new Date('2024-10-01'));
+  });
+
+  it('holidays는 10월 휴일인 개천절, 한글날이 지정되어 있어야 한다', () => {
+    const { result } = renderHook(() => useCalendarView());
+    expect(result.current.holidays).toEqual({ '2024-10-03': '개천절', '2024-10-09': '한글날' });
+  });
+
+  it("view를 'week'으로 변경 시 적절하게 반영된다", () => {
+    const { result } = renderHook(() => useCalendarView());
+
+    act(() => result.current.setView('week'));
+
+    expect(result.current.view).toBe('week');
+  });
+
+  it("주간 뷰에서 다음으로 navigate시 7일 후 '2024-10-08' 날짜로 지정이 된다", () => {
+    const { result } = renderHook(() => useCalendarView());
+
+    act(() => result.current.setView('week'));
+    act(() => result.current.navigate('next'));
+
+    expect(result.current.currentDate).toEqual(new Date('2024-10-08'));
+  });
+
+  it("주간 뷰에서 이전으로 navigate시 7일 전 '2024-09-24' 날짜로 지정이 된다", () => {
+    const { result } = renderHook(() => useCalendarView());
+
+    act(() => result.current.setView('week'));
+    act(() => result.current.navigate('prev'));
+
+    expect(result.current.currentDate).toEqual(new Date('2024-09-24'));
+  });
+
+  it("월간 뷰에서 다음으로 navigate시 한 달 후 '2024-11-01' 날짜여야 한다", () => {
+    const { result } = renderHook(() => useCalendarView());
+
+    act(() => result.current.navigate('next'));
+
+    expect(result.current.currentDate).toEqual(new Date('2024-11-01'));
+  });
+
+  it("월간 뷰에서 이전으로 navigate시 한 달 전 '2024-09-01' 날짜여야 한다", () => {
+    const { result } = renderHook(() => useCalendarView());
+
+    act(() => result.current.navigate('prev'));
+
+    expect(result.current.currentDate).toEqual(new Date('2024-09-01'));
+  });
+
+  it("currentDate가 '2024-01-01' 변경되면 1월 휴일 '신정'으로 업데이트되어야 한다", async () => {
+    const { result } = renderHook(() => useCalendarView());
+
+    act(() => result.current.setCurrentDate(new Date('2024-01-01')));
+
+    expect(result.current.holidays).toEqual({ '2024-01-01': '신정' });
+  });
 });
-
-it("view를 'week'으로 변경 시 적절하게 반영된다", () => {});
-
-it("주간 뷰에서 다음으로 navigate시 7일 후 '2024-10-08' 날짜로 지정이 된다", () => {});
-
-it("주간 뷰에서 이전으로 navigate시 7일 후 '2024-09-24' 날짜로 지정이 된다", () => {});
-
-it("월간 뷰에서 다음으로 navigate시 한 달 전 '2024-11-01' 날짜여야 한다", () => {});
-
-it("월간 뷰에서 이전으로 navigate시 한 달 전 '2024-09-01' 날짜여야 한다", () => {});
-
-it("currentDate가 '2024-01-01' 변경되면 1월 휴일 '신정'으로 업데이트되어야 한다", async () => {});

--- a/src/__tests__/hooks/easy.useSearch.spec.ts
+++ b/src/__tests__/hooks/easy.useSearch.spec.ts
@@ -3,12 +3,416 @@ import { act, renderHook } from '@testing-library/react';
 import { useSearch } from '../../hooks/useSearch.ts';
 import { Event } from '../../types.ts';
 
-it('검색어가 비어있을 때 모든 이벤트를 반환해야 한다', () => {});
+describe('useSearch', () => {
+  it('검색어가 비어있을 때 모든 이벤트를 반환해야 한다', () => {
+    const events: Event[] = [
+      {
+        id: 'a7f8d5e0-3f4b-4b8a-9e20-1f46a8c5e123',
+        title: 'Cooking Workshop',
+        date: '2024-11-15',
+        startTime: '14:00',
+        endTime: '17:00',
+        description: 'Learn to cook Italian dishes',
+        location: 'Culinary Arts Studio',
+        category: 'Education',
+        repeat: { type: 'none', interval: 0 },
+        notificationTime: 45,
+      },
+      {
+        id: '5e3d9b2c-17c2-4c8e-8c2b-0f0c0d1f9e56',
+        title: 'Photography Walk',
+        date: '2024-11-18',
+        startTime: '08:00',
+        endTime: '10:30',
+        description: 'Explore urban landscapes through photography',
+        location: 'Central Park',
+        category: 'Hobby',
+        repeat: { type: 'monthly', interval: 1, endDate: '2025-06-18' },
+        notificationTime: 30,
+      },
+      {
+        id: 'd1f74a3a-8b5e-4fa9-904f-7e0a14e9b333',
+        title: 'Language Exchange Meetup',
+        date: '2024-11-20',
+        startTime: '19:00',
+        endTime: '21:00',
+        description: 'Practice languages with native speakers',
+        location: 'Community Center',
+        category: 'Social',
+        repeat: { type: 'weekly', interval: 1, endDate: '2025-02-01' },
+        notificationTime: 20,
+      },
+      {
+        id: 'f5c1b8d4-6a4f-4a11-8234-2f3a1d5c9f98',
+        title: 'Yoga Class',
+        date: '2024-11-22',
+        startTime: '06:00',
+        endTime: '07:00',
+        description: 'Morning Vinyasa yoga for flexibility',
+        location: 'Green Hills Yoga Studio',
+        category: 'Health',
+        repeat: { type: 'daily', interval: 1, endDate: '2024-12-01' },
+        notificationTime: 15,
+      },
+      {
+        id: '9b7c8d5e-1f0e-4d8a-bf23-3e9a1c4e7a45',
+        title: 'Book Club Meeting',
+        date: '2024-11-25',
+        startTime: '18:00',
+        endTime: '19:30',
+        description: 'Discuss the monthly book selection',
+        location: 'Local Library',
+        category: 'Literature',
+        repeat: { type: 'monthly', interval: 1 },
+        notificationTime: 60,
+      },
+    ];
+    const { result } = renderHook(() => useSearch(events, new Date(), 'month'));
 
-it('검색어에 맞는 이벤트만 필터링해야 한다', () => {});
+    expect(result.current.filteredEvents).toEqual(events);
+  });
 
-it('검색어가 제목, 설명, 위치 중 하나라도 일치하면 해당 이벤트를 반환해야 한다', () => {});
+  it('검색어에 제목, 설명, 위치에 맞는 이벤트만 필터링 해야 한다.', () => {
+    const events: Event[] = [
+      {
+        id: 'a7f8d5e0-3f4b-4b8a-9e20-1f46a8c5e123',
+        title: 'Cooking Workshop',
+        date: '2024-11-15',
+        startTime: '14:00',
+        endTime: '17:00',
+        description: 'Learn to cook Italian dishes',
+        location: 'Culinary Arts Studio',
+        category: 'Education',
+        repeat: { type: 'none', interval: 0 },
+        notificationTime: 45,
+      },
+      {
+        id: '5e3d9b2c-17c2-4c8e-8c2b-0f0c0d1f9e56',
+        title: 'Photography Walk',
+        date: '2024-11-18',
+        startTime: '08:00',
+        endTime: '10:30',
+        description: 'Explore urban landscapes through photography',
+        location: 'Central Park',
+        category: 'Hobby',
+        repeat: { type: 'monthly', interval: 1, endDate: '2025-06-18' },
+        notificationTime: 30,
+      },
+      {
+        id: 'd1f74a3a-8b5e-4fa9-904f-7e0a14e9b333',
+        title: 'Language Exchange Meetup',
+        date: '2024-11-20',
+        startTime: '19:00',
+        endTime: '21:00',
+        description: 'Practice languages with native speakers',
+        location: 'Community Center',
+        category: 'Social',
+        repeat: { type: 'weekly', interval: 1, endDate: '2025-02-01' },
+        notificationTime: 20,
+      },
+      {
+        id: 'f5c1b8d4-6a4f-4a11-8234-2f3a1d5c9f98',
+        title: 'Yoga Class',
+        date: '2024-11-22',
+        startTime: '06:00',
+        endTime: '07:00',
+        description: 'Morning Vinyasa yoga for flexibility',
+        location: 'Green Hills Yoga Studio',
+        category: 'Health',
+        repeat: { type: 'daily', interval: 1, endDate: '2024-12-01' },
+        notificationTime: 15,
+      },
+      {
+        id: '9b7c8d5e-1f0e-4d8a-bf23-3e9a1c4e7a45',
+        title: 'Book Club Meeting',
+        date: '2024-11-25',
+        startTime: '18:00',
+        endTime: '19:30',
+        description: 'Discuss the monthly book selection',
+        location: 'Local Library',
+        category: 'Literature',
+        repeat: { type: 'monthly', interval: 1 },
+        notificationTime: 60,
+      },
+    ];
+    const { result } = renderHook(() => useSearch(events, new Date(), 'month'));
 
-it('현재 뷰(주간/월간)에 해당하는 이벤트만 반환해야 한다', () => {});
+    act(() => result.current.setSearchTerm('Cooking Workshop'));
 
-it("검색어를 '회의'에서 '점심'으로 변경하면 필터링된 결과가 즉시 업데이트되어야 한다", () => {});
+    expect(result.current.filteredEvents).toEqual([
+      {
+        id: 'a7f8d5e0-3f4b-4b8a-9e20-1f46a8c5e123',
+        title: 'Cooking Workshop',
+        date: '2024-11-15',
+        startTime: '14:00',
+        endTime: '17:00',
+        description: 'Learn to cook Italian dishes',
+        location: 'Culinary Arts Studio',
+        category: 'Education',
+        repeat: { type: 'none', interval: 0 },
+        notificationTime: 45,
+      },
+    ]);
+    act(() => result.current.setSearchTerm('landscapes through'));
+
+    expect(result.current.filteredEvents).toEqual([
+      {
+        id: '5e3d9b2c-17c2-4c8e-8c2b-0f0c0d1f9e56',
+        title: 'Photography Walk',
+        date: '2024-11-18',
+        startTime: '08:00',
+        endTime: '10:30',
+        description: 'Explore urban landscapes through photography',
+        location: 'Central Park',
+        category: 'Hobby',
+        repeat: { type: 'monthly', interval: 1, endDate: '2025-06-18' },
+        notificationTime: 30,
+      },
+    ]);
+
+    act(() => result.current.setSearchTerm('Hills'));
+
+    expect(result.current.filteredEvents).toEqual([
+      {
+        id: 'f5c1b8d4-6a4f-4a11-8234-2f3a1d5c9f98',
+        title: 'Yoga Class',
+        date: '2024-11-22',
+        startTime: '06:00',
+        endTime: '07:00',
+        description: 'Morning Vinyasa yoga for flexibility',
+        location: 'Green Hills Yoga Studio',
+        category: 'Health',
+        repeat: { type: 'daily', interval: 1, endDate: '2024-12-01' },
+        notificationTime: 15,
+      },
+    ]);
+  });
+
+  it('현재 뷰(주간/월간)에 해당하는 이벤트만 반환해야 한다', () => {
+    const events: Event[] = [
+      {
+        id: 'a7f8d5e0-3f4b-4b8a-9e20-1f46a8c5e123',
+        title: 'Cooking Workshop',
+        date: '2024-11-15',
+        startTime: '14:00',
+        endTime: '17:00',
+        description: 'Learn to cook Italian dishes',
+        location: 'Culinary Arts Studio',
+        category: 'Education',
+        repeat: { type: 'none', interval: 0 },
+        notificationTime: 45,
+      },
+      {
+        id: '5e3d9b2c-17c2-4c8e-8c2b-0f0c0d1f9e56',
+        title: 'Photography Walk',
+        date: '2024-11-06',
+        startTime: '08:00',
+        endTime: '10:30',
+        description: 'Explore urban landscapes through photography',
+        location: 'Central Park',
+        category: 'Hobby',
+        repeat: { type: 'monthly', interval: 1, endDate: '2025-06-18' },
+        notificationTime: 30,
+      },
+      {
+        id: 'd1f74a3a-8b5e-4fa9-904f-7e0a14e9b333',
+        title: 'Language Exchange Meetup',
+        date: '2024-11-07',
+        startTime: '19:00',
+        endTime: '21:00',
+        description: 'Practice languages with native speakers',
+        location: 'Community Center',
+        category: 'Social',
+        repeat: { type: 'weekly', interval: 1, endDate: '2025-02-01' },
+        notificationTime: 20,
+      },
+      {
+        id: 'f5c1b8d4-6a4f-4a11-8234-2f3a1d5c9f98',
+        title: 'Yoga Class',
+        date: '2024-11-22',
+        startTime: '06:00',
+        endTime: '07:00',
+        description: 'Morning Vinyasa yoga for flexibility',
+        location: 'Green Hills Yoga Studio',
+        category: 'Health',
+        repeat: { type: 'daily', interval: 1, endDate: '2024-12-01' },
+        notificationTime: 15,
+      },
+      {
+        id: '9b7c8d5e-1f0e-4d8a-bf23-3e9a1c4e7a45',
+        title: 'Book Club Meeting',
+        date: '2024-11-25',
+        startTime: '18:00',
+        endTime: '19:30',
+        description: 'Discuss the monthly book selection',
+        location: 'Local Library',
+        category: 'Literature',
+        repeat: { type: 'monthly', interval: 1 },
+        notificationTime: 60,
+      },
+    ];
+
+    let view: 'week' | 'month' = 'week';
+    const { result } = renderHook(
+      ({ view }: { view: 'week' | 'month' }) => useSearch(events, new Date(), view),
+      { initialProps: { view } }
+    );
+
+    expect(result.current.filteredEvents).toEqual([
+      {
+        id: '5e3d9b2c-17c2-4c8e-8c2b-0f0c0d1f9e56',
+        title: 'Photography Walk',
+        date: '2024-11-06',
+        startTime: '08:00',
+        endTime: '10:30',
+        description: 'Explore urban landscapes through photography',
+        location: 'Central Park',
+        category: 'Hobby',
+        repeat: { type: 'monthly', interval: 1, endDate: '2025-06-18' },
+        notificationTime: 30,
+      },
+      {
+        id: 'd1f74a3a-8b5e-4fa9-904f-7e0a14e9b333',
+        title: 'Language Exchange Meetup',
+        date: '2024-11-07',
+        startTime: '19:00',
+        endTime: '21:00',
+        description: 'Practice languages with native speakers',
+        location: 'Community Center',
+        category: 'Social',
+        repeat: { type: 'weekly', interval: 1, endDate: '2025-02-01' },
+        notificationTime: 20,
+      },
+    ]);
+
+    view = 'month';
+
+    expect(result.current.filteredEvents).toEqual([
+      {
+        id: '5e3d9b2c-17c2-4c8e-8c2b-0f0c0d1f9e56',
+        title: 'Photography Walk',
+        date: '2024-11-06',
+        startTime: '08:00',
+        endTime: '10:30',
+        description: 'Explore urban landscapes through photography',
+        location: 'Central Park',
+        category: 'Hobby',
+        repeat: { type: 'monthly', interval: 1, endDate: '2025-06-18' },
+        notificationTime: 30,
+      },
+      {
+        id: 'd1f74a3a-8b5e-4fa9-904f-7e0a14e9b333',
+        title: 'Language Exchange Meetup',
+        date: '2024-11-07',
+        startTime: '19:00',
+        endTime: '21:00',
+        description: 'Practice languages with native speakers',
+        location: 'Community Center',
+        category: 'Social',
+        repeat: { type: 'weekly', interval: 1, endDate: '2025-02-01' },
+        notificationTime: 20,
+      },
+    ]);
+  });
+
+  it("검색어를 'Yoga'에서 'Photography'으로 변경하면 필터링된 결과가 즉시 업데이트되어야 한다", () => {
+    const events: Event[] = [
+      {
+        id: 'a7f8d5e0-3f4b-4b8a-9e20-1f46a8c5e123',
+        title: 'Cooking Workshop',
+        date: '2024-11-15',
+        startTime: '14:00',
+        endTime: '17:00',
+        description: 'Learn to cook Italian dishes',
+        location: 'Culinary Arts Studio',
+        category: 'Education',
+        repeat: { type: 'none', interval: 0 },
+        notificationTime: 45,
+      },
+      {
+        id: '5e3d9b2c-17c2-4c8e-8c2b-0f0c0d1f9e56',
+        title: 'Photography Walk',
+        date: '2024-11-06',
+        startTime: '08:00',
+        endTime: '10:30',
+        description: 'Explore urban landscapes through photography',
+        location: 'Central Park',
+        category: 'Hobby',
+        repeat: { type: 'monthly', interval: 1, endDate: '2025-06-18' },
+        notificationTime: 30,
+      },
+      {
+        id: 'd1f74a3a-8b5e-4fa9-904f-7e0a14e9b333',
+        title: 'Language Exchange Meetup',
+        date: '2024-11-07',
+        startTime: '19:00',
+        endTime: '21:00',
+        description: 'Practice languages with native speakers',
+        location: 'Community Center',
+        category: 'Social',
+        repeat: { type: 'weekly', interval: 1, endDate: '2025-02-01' },
+        notificationTime: 20,
+      },
+      {
+        id: 'f5c1b8d4-6a4f-4a11-8234-2f3a1d5c9f98',
+        title: 'Yoga Class',
+        date: '2024-11-22',
+        startTime: '06:00',
+        endTime: '07:00',
+        description: 'Morning Vinyasa yoga for flexibility',
+        location: 'Green Hills Yoga Studio',
+        category: 'Health',
+        repeat: { type: 'daily', interval: 1, endDate: '2024-12-01' },
+        notificationTime: 15,
+      },
+      {
+        id: '9b7c8d5e-1f0e-4d8a-bf23-3e9a1c4e7a45',
+        title: 'Book Club Meeting',
+        date: '2024-11-25',
+        startTime: '18:00',
+        endTime: '19:30',
+        description: 'Discuss the monthly book selection',
+        location: 'Local Library',
+        category: 'Literature',
+        repeat: { type: 'monthly', interval: 1 },
+        notificationTime: 60,
+      },
+    ];
+
+    const { result } = renderHook(() => useSearch(events, new Date(), 'month'));
+
+    act(() => result.current.setSearchTerm('Yoga'));
+
+    expect(result.current.filteredEvents).toEqual([
+      {
+        id: 'f5c1b8d4-6a4f-4a11-8234-2f3a1d5c9f98',
+        title: 'Yoga Class',
+        date: '2024-11-22',
+        startTime: '06:00',
+        endTime: '07:00',
+        description: 'Morning Vinyasa yoga for flexibility',
+        location: 'Green Hills Yoga Studio',
+        category: 'Health',
+        repeat: { type: 'daily', interval: 1, endDate: '2024-12-01' },
+        notificationTime: 15,
+      },
+    ]);
+
+    act(() => result.current.setSearchTerm('Photography'));
+
+    expect(result.current.filteredEvents).toEqual([
+      {
+        id: '5e3d9b2c-17c2-4c8e-8c2b-0f0c0d1f9e56',
+        title: 'Photography Walk',
+        date: '2024-11-06',
+        startTime: '08:00',
+        endTime: '10:30',
+        description: 'Explore urban landscapes through photography',
+        location: 'Central Park',
+        category: 'Hobby',
+        repeat: { type: 'monthly', interval: 1, endDate: '2025-06-18' },
+        notificationTime: 30,
+      },
+    ]);
+  });
+});

--- a/src/__tests__/hooks/medium.useEventOperations.spec.ts
+++ b/src/__tests__/hooks/medium.useEventOperations.spec.ts
@@ -1,25 +1,297 @@
-import { act, renderHook } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 
-import {
-  setupMockHandlerCreation,
-  setupMockHandlerDeletion,
-  setupMockHandlerUpdating,
-} from '../../__mocks__/handlersUtils.ts';
 import { useEventOperations } from '../../hooks/useEventOperations.ts';
 import { server } from '../../setupTests.ts';
-import { Event } from '../../types.ts';
 
-it('저장되어있는 초기 이벤트 데이터를 적절하게 불러온다', async () => {});
+const toast = vi.fn();
 
-it('정의된 이벤트 정보를 기준으로 적절하게 저장이 된다', async () => {});
+vi.mock('@chakra-ui/react', () => {
+  return {
+    useToast: () => {
+      return toast;
+    },
+  };
+});
 
-it("새로 정의된 'title', 'endTime' 기준으로 적절하게 일정이 업데이트 된다", async () => {});
+describe('일정들을 네트워크 요청 처리한다.', () => {
+  it('저장되어있는 초기 이벤트 데이터를 적절하게 불러온다', async () => {
+    const { result } = renderHook(() => useEventOperations(false));
 
-it('존재하는 이벤트 삭제 시 에러없이 아이템이 삭제된다.', async () => {});
+    await waitFor(() => {
+      expect(result.current.events).toEqual([
+        {
+          id: '1',
+          title: '기존 회의',
+          date: '2024-10-15',
+          startTime: '09:00',
+          endTime: '10:00',
+          description: '기존 팀 미팅',
+          location: '회의실 B',
+          category: '업무',
+          repeat: { type: 'none', interval: 0 },
+          notificationTime: 10,
+        },
+      ]);
 
-it("이벤트 로딩 실패 시 '이벤트 로딩 실패'라는 텍스트와 함께 에러 토스트가 표시되어야 한다", async () => {});
+      expect(toast).toHaveBeenCalledWith({
+        duration: 1000,
+        status: 'info',
+        title: '일정 로딩 완료!',
+      });
+    });
+  });
 
-it("존재하지 않는 이벤트 수정 시 '일정 저장 실패'라는 토스트가 노출되며 에러 처리가 되어야 한다", async () => {});
+  it('정의된 이벤트 정보를 기준으로 적절하게 저장이 된다', async () => {
+    const { result } = renderHook(() => useEventOperations(true));
 
-it("네트워크 오류 시 '일정 삭제 실패'라는 텍스트가 노출되며 이벤트 삭제가 실패해야 한다", async () => {});
+    act(() => {
+      result.current.saveEvent({
+        id: '1',
+        title: '변경회의',
+        date: '2024-10-15',
+        startTime: '09:00',
+        endTime: '14:00',
+        description: '변경 팀 미팅',
+        location: '화장실 B',
+        category: '용변',
+        repeat: { type: 'none', interval: 0 },
+        notificationTime: 10,
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.events).toEqual([
+        {
+          id: '1',
+          title: '변경회의',
+          date: '2024-10-15',
+          startTime: '09:00',
+          endTime: '14:00',
+          description: '변경 팀 미팅',
+          location: '화장실 B',
+          category: '용변',
+          repeat: { type: 'none', interval: 0 },
+          notificationTime: 10,
+        },
+      ]);
+
+      expect(toast).toHaveBeenCalledWith({
+        duration: 3000,
+        isClosable: true,
+        status: 'success',
+        title: '일정이 수정되었습니다.',
+      });
+    });
+  });
+
+  it("새로 정의된 'title', 'endTime' 기준으로 적절하게 일정이 업데이트 된다", async () => {
+    const { result } = renderHook(() => useEventOperations(false));
+
+    act(() => {
+      result.current.saveEvent({
+        id: '2',
+        title: '추가 용변',
+        date: '2024-10-14',
+        startTime: '02:00',
+        endTime: '04:00',
+        description: '조그만한 용변',
+        location: '화장실',
+        category: '용변 업무',
+        repeat: { type: 'none', interval: 0 },
+        notificationTime: 10,
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.events).toEqual([
+        {
+          category: '업무',
+          date: '2024-10-15',
+          description: '기존 팀 미팅',
+          endTime: '10:00',
+          id: '1',
+          location: '회의실 B',
+          notificationTime: 10,
+          repeat: {
+            interval: 0,
+            type: 'none',
+          },
+          startTime: '09:00',
+          title: '기존 회의',
+        },
+        {
+          category: '용변 업무',
+          date: '2024-10-14',
+          description: '조그만한 용변',
+          endTime: '04:00',
+          id: '2',
+          location: '화장실',
+          notificationTime: 10,
+          repeat: {
+            interval: 0,
+            type: 'none',
+          },
+          startTime: '02:00',
+          title: '추가 용변',
+        },
+      ]);
+
+      expect(toast).toHaveBeenCalledWith({
+        duration: 3000,
+        isClosable: true,
+        status: 'success',
+        title: '일정이 추가되었습니다.',
+      });
+    });
+  });
+
+  it('존재하는 이벤트 삭제 시 에러없이 아이템이 삭제된다.', async () => {
+    const { result } = renderHook(() => useEventOperations(false));
+
+    act(() => {
+      result.current.saveEvent({
+        id: '2',
+        title: '추가 용변',
+        date: '2024-10-14',
+        startTime: '02:00',
+        endTime: '04:00',
+        description: '조그만한 용변',
+        location: '화장실',
+        category: '용변 업무',
+        repeat: { type: 'none', interval: 0 },
+        notificationTime: 10,
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.events).toEqual([
+        {
+          category: '업무',
+          date: '2024-10-15',
+          description: '기존 팀 미팅',
+          endTime: '10:00',
+          id: '1',
+          location: '회의실 B',
+          notificationTime: 10,
+          repeat: {
+            interval: 0,
+            type: 'none',
+          },
+          startTime: '09:00',
+          title: '기존 회의',
+        },
+        {
+          category: '용변 업무',
+          date: '2024-10-14',
+          description: '조그만한 용변',
+          endTime: '04:00',
+          id: '2',
+          location: '화장실',
+          notificationTime: 10,
+          repeat: {
+            interval: 0,
+            type: 'none',
+          },
+          startTime: '02:00',
+          title: '추가 용변',
+        },
+      ]);
+    });
+
+    act(() => {
+      result.current.deleteEvent('1');
+    });
+
+    await waitFor(() => {
+      expect(result.current.events).toEqual([
+        {
+          category: '용변 업무',
+          date: '2024-10-14',
+          description: '조그만한 용변',
+          endTime: '04:00',
+          id: '2',
+          location: '화장실',
+          notificationTime: 10,
+          repeat: {
+            interval: 0,
+            type: 'none',
+          },
+          startTime: '02:00',
+          title: '추가 용변',
+        },
+      ]);
+    });
+  });
+
+  it("이벤트 로딩 실패 시 '이벤트 로딩 실패'라는 텍스트와 함께 에러 토스트가 표시되어야 한다", async () => {
+    server.use(
+      http.get('*', () => {
+        return HttpResponse.error();
+      })
+    );
+    const { result } = renderHook(() => useEventOperations(false));
+
+    await waitFor(() => {
+      expect(result.current.events).toEqual([]);
+      expect(toast).toHaveBeenCalledWith({
+        duration: 3000,
+        isClosable: true,
+        status: 'error',
+        title: '이벤트 로딩 실패',
+      });
+    });
+  });
+
+  it("존재하지 않는 이벤트 수정 시 '일정 저장 실패'라는 토스트가 노출되며 에러 처리가 되어야 한다", async () => {
+    const { result } = renderHook(() => useEventOperations(true));
+
+    act(() => {
+      result.current.saveEvent({
+        id: '3',
+        title: '기존',
+        date: '2024-10-15',
+        startTime: '09:00',
+        endTime: '10:00',
+        description: 'ㅂ 팀 미팅',
+        location: '회의실 B',
+        category: '업무릎팍',
+        repeat: { type: 'none', interval: 0 },
+        notificationTime: 10,
+      });
+    });
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith({
+        duration: 3000,
+        isClosable: true,
+        status: 'error',
+        title: '일정 저장 실패',
+      });
+    });
+  });
+
+  it("네트워크 오류 시 '일정 삭제 실패'라는 텍스트가 노출되며 이벤트 삭제가 실패해야 한다", async () => {
+    const { result } = renderHook(() => useEventOperations(false));
+    act(() => {
+      server.use(
+        http.delete('*', () => {
+          return HttpResponse.error();
+        })
+      );
+    });
+
+    act(() => {
+      result.current.deleteEvent('1');
+    });
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith({
+        title: '일정 삭제 실패',
+        status: 'error',
+        duration: 3000,
+        isClosable: true,
+      });
+    });
+  });
+});

--- a/src/__tests__/hooks/medium.useNotifications.spec.ts
+++ b/src/__tests__/hooks/medium.useNotifications.spec.ts
@@ -119,17 +119,11 @@ describe('useNotification', () => {
       },
     ]);
 
-    act(() => vi.advanceTimersByTime(1000));
+    act(() => {
+      result.current.removeNotification(0);
+      vi.advanceTimersByTime(1000);
+    });
 
-    expect(result.current.notifications).not.toEqual([
-      {
-        id: 'a7f8d5e0-3f4b-4b8a-9e20-1f46a8c5e123',
-        message: '45분 후 Cooking Workshop 일정이 시작됩니다.',
-      },
-      {
-        id: 'a7f8d5e0-3f4b-4b8a-9e20-1f46a8c5e123',
-        message: '45분 후 Cooking Workshop 일정이 시작됩니다.',
-      },
-    ]);
+    expect(result.current.notifications).toHaveLength(0);
   });
 });

--- a/src/__tests__/hooks/medium.useNotifications.spec.ts
+++ b/src/__tests__/hooks/medium.useNotifications.spec.ts
@@ -2,8 +2,6 @@ import { act, renderHook } from '@testing-library/react';
 
 import { useNotifications } from '../../hooks/useNotifications.ts';
 import { Event } from '../../types.ts';
-import { formatDate } from '../../utils/dateUtils.ts';
-import { parseHM } from '../utils.ts';
 
 describe('useNotification', () => {
   const events: Event[] = [

--- a/src/__tests__/hooks/medium.useNotifications.spec.ts
+++ b/src/__tests__/hooks/medium.useNotifications.spec.ts
@@ -5,10 +5,133 @@ import { Event } from '../../types.ts';
 import { formatDate } from '../../utils/dateUtils.ts';
 import { parseHM } from '../utils.ts';
 
-it('초기 상태에서는 알림이 없어야 한다', () => {});
+describe('useNotification', () => {
+  const events: Event[] = [
+    {
+      id: 'a7f8d5e0-3f4b-4b8a-9e20-1f46a8c5e123',
+      title: 'Cooking Workshop',
+      date: '2024-11-15',
+      startTime: '14:00',
+      endTime: '17:00',
+      description: 'Learn to cook Italian dishes',
+      location: 'Culinary Arts Studio',
+      category: 'Education',
+      repeat: { type: 'none', interval: 0 },
+      notificationTime: 45,
+    },
+    {
+      id: '5e3d9b2c-17c2-4c8e-8c2b-0f0c0d1f9e56',
+      title: 'Photography Walk',
+      date: '2024-11-18',
+      startTime: '08:00',
+      endTime: '10:30',
+      description: 'Explore urban landscapes through photography',
+      location: 'Central Park',
+      category: 'Hobby',
+      repeat: { type: 'monthly', interval: 1, endDate: '2025-06-18' },
+      notificationTime: 30,
+    },
+    {
+      id: 'd1f74a3a-8b5e-4fa9-904f-7e0a14e9b333',
+      title: 'Language Exchange Meetup',
+      date: '2024-11-20',
+      startTime: '19:00',
+      endTime: '21:00',
+      description: 'Practice languages with native speakers',
+      location: 'Community Center',
+      category: 'Social',
+      repeat: { type: 'weekly', interval: 1, endDate: '2025-02-01' },
+      notificationTime: 20,
+    },
+    {
+      id: 'f5c1b8d4-6a4f-4a11-8234-2f3a1d5c9f98',
+      title: 'Yoga Class',
+      date: '2024-11-22',
+      startTime: '06:00',
+      endTime: '07:00',
+      description: 'Morning Vinyasa yoga for flexibility',
+      location: 'Green Hills Yoga Studio',
+      category: 'Health',
+      repeat: { type: 'daily', interval: 1, endDate: '2024-12-01' },
+      notificationTime: 15,
+    },
+    {
+      id: '9b7c8d5e-1f0e-4d8a-bf23-3e9a1c4e7a45',
+      title: 'Book Club Meeting',
+      date: '2024-11-25',
+      startTime: '18:00',
+      endTime: '19:30',
+      description: 'Discuss the monthly book selection',
+      location: 'Local Library',
+      category: 'Literature',
+      repeat: { type: 'monthly', interval: 1 },
+      notificationTime: 60,
+    },
+  ];
 
-it('지정된 시간이 된 경우 알림이 새롭게 생성되어 추가된다', () => {});
+  vi.useFakeTimers();
 
-it('index를 기준으로 알림을 적절하게 제거할 수 있다', () => {});
+  it('초기 상태에서는 알림이 없어야 한다', () => {
+    const { result } = renderHook(() => useNotifications(events));
 
-it('이미 알림이 발생한 이벤트에 대해서는 중복 알림이 발생하지 않아야 한다', () => {});
+    expect(result.current.notifications).toEqual([]);
+  });
+
+  it('지정된 시간이 된 경우 알림이 새롭게 생성되어 추가된다', () => {
+    const mockDateTime = new Date('2024-11-15T13:50');
+    vi.setSystemTime(mockDateTime);
+
+    const { result } = renderHook(() => useNotifications(events));
+
+    act(() => vi.advanceTimersByTime(1000));
+
+    expect(result.current.notifications).toEqual([
+      {
+        id: 'a7f8d5e0-3f4b-4b8a-9e20-1f46a8c5e123',
+        message: '45분 후 Cooking Workshop 일정이 시작됩니다.',
+      },
+    ]);
+  });
+
+  it('index를 기준으로 알림을 적절하게 제거할 수 있다', () => {
+    const mockDateTime = new Date('2024-11-15T13:50');
+    vi.setSystemTime(mockDateTime);
+
+    const { result } = renderHook(() => useNotifications(events));
+
+    act(() => vi.advanceTimersByTime(1000));
+
+    act(() => result.current.removeNotification(0));
+
+    expect(result.current.notifications).toEqual([]);
+  });
+
+  it('이미 알림이 발생한 이벤트에 대해서는 중복 알림이 발생하지 않아야 한다', () => {
+    const mockDateTime = new Date('2024-11-15T13:50');
+    vi.setSystemTime(mockDateTime);
+
+    const { result } = renderHook(() => useNotifications(events));
+
+    act(() => vi.advanceTimersByTime(1000));
+
+    expect(result.current.notifications).toEqual([
+      {
+        id: 'a7f8d5e0-3f4b-4b8a-9e20-1f46a8c5e123',
+        message: '45분 후 Cooking Workshop 일정이 시작됩니다.',
+      },
+    ]);
+
+    act(() => vi.advanceTimersByTime(1000));
+
+    expect(result.current.notifications).not.toEqual([
+      {
+        id: 'a7f8d5e0-3f4b-4b8a-9e20-1f46a8c5e123',
+        message: '45분 후 Cooking Workshop 일정이 시작됩니다.',
+      },
+      {
+        id: 'a7f8d5e0-3f4b-4b8a-9e20-1f46a8c5e123',
+        message: '45분 후 Cooking Workshop 일정이 시작됩니다.',
+      },
+    ]);
+  });
+});

--- a/src/__tests__/medium.integration.spec.tsx
+++ b/src/__tests__/medium.integration.spec.tsx
@@ -1,13 +1,16 @@
 import { ChakraProvider } from '@chakra-ui/react';
 import { render, screen, within, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
+import { OverlayProvider } from 'overlay-kit';
 
 import App from '../App';
 
 const renderApp = () => {
   return render(
     <ChakraProvider>
-      <App />
+      <OverlayProvider>
+        <App />
+      </OverlayProvider>
     </ChakraProvider>
   );
 };

--- a/src/__tests__/medium.integration.spec.tsx
+++ b/src/__tests__/medium.integration.spec.tsx
@@ -1,11 +1,8 @@
 import { ChakraProvider } from '@chakra-ui/react';
-import { render, screen, within, act, waitFor } from '@testing-library/react';
-import { UserEvent, userEvent } from '@testing-library/user-event';
-import { ReactElement } from 'react';
+import { render, screen, within, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 
 import App from '../App';
-import { server } from '../setupTests';
-import { Event } from '../types';
 
 const renderApp = () => {
   return render(
@@ -181,29 +178,269 @@ describe('일정 CRUD 및 기본 기능', () => {
 });
 
 describe('일정 뷰', () => {
-  it('주별 뷰를 선택 후 해당 주에 일정이 없으면, 일정이 표시되지 않는다.', async () => {});
+  it('주별 뷰를 선택 후 해당 주에 일정이 없으면, 일정이 표시되지 않는다.', async () => {
+    vi.setSystemTime(new Date('2024-11-09'));
+    renderApp();
 
-  it('주별 뷰 선택 후 해당 일자에 일정이 존재한다면 해당 일정이 정확히 표시된다', async () => {});
+    const viewSelect: HTMLSelectElement = screen.getByLabelText(/view/i);
+    await userEvent.selectOptions(viewSelect, 'week');
+    const emptyEventText = await screen.findByText(/검색 결과가 없습니다/i);
+    expect(emptyEventText).toBeInTheDocument();
+  });
 
-  it('월별 뷰에 일정이 없으면, 일정이 표시되지 않아야 한다.', async () => {});
+  it('주별 뷰 선택 후 해당 일자에 일정이 존재한다면 해당 일정이 정확히 표시된다', async () => {
+    vi.setSystemTime(new Date('2024-10-14'));
+    renderApp();
 
-  it('월별 뷰에 일정이 정확히 표시되는지 확인한다', async () => {});
+    const viewSelect: HTMLSelectElement = screen.getByLabelText(/view/i);
+    await userEvent.selectOptions(viewSelect, 'week');
 
-  it('달력에 1월 1일(신정)이 공휴일로 표시되는지 확인한다', async () => {});
+    const eventList = screen.getByTestId(/event-list/i);
+    const eventTitle = await within(eventList).findByText(/기존 회의/i);
+    const eventDate = await within(eventList).findByText(/2024-10-15/i);
+    const eventStartTime = await within(eventList).findByText(/09:00 - 10:00/i);
+    const eventDescription = await within(eventList).findByText(/기존 팀 미팅/i);
+    const eventLocation = await within(eventList).findByText(/회의실 B/i);
+    const eventCategory = await within(eventList).findByText(/카테고리: 업무/i);
+
+    expect(eventTitle).toBeInTheDocument();
+    expect(eventDate).toBeInTheDocument();
+    expect(eventStartTime).toBeInTheDocument();
+    expect(eventDescription).toBeInTheDocument();
+    expect(eventLocation).toBeInTheDocument();
+    expect(eventCategory).toBeInTheDocument();
+  });
+
+  it('월별 뷰에 일정이 없으면, 일정이 표시되지 않아야 한다.', async () => {
+    vi.setSystemTime(new Date('2024-02-14'));
+    renderApp();
+
+    const emptyEventText = await screen.findByText(/검색 결과가 없습니다/i);
+    expect(emptyEventText).toBeInTheDocument();
+  });
+
+  it('월별 뷰에 일정이 정확히 표시되는지 확인한다', async () => {
+    vi.setSystemTime(new Date('2024-10-14'));
+    renderApp();
+
+    const eventList = screen.getByTestId(/event-list/i);
+    const eventTitle = await within(eventList).findByText(/기존 회의/i);
+    const eventDate = await within(eventList).findByText(/2024-10-15/i);
+    const eventStartTime = await within(eventList).findByText(/09:00 - 10:00/i);
+    const eventDescription = await within(eventList).findByText(/기존 팀 미팅/i);
+    const eventLocation = await within(eventList).findByText(/회의실 B/i);
+    const eventCategory = await within(eventList).findByText(/카테고리: 업무/i);
+
+    expect(eventTitle).toBeInTheDocument();
+    expect(eventDate).toBeInTheDocument();
+    expect(eventStartTime).toBeInTheDocument();
+    expect(eventDescription).toBeInTheDocument();
+    expect(eventLocation).toBeInTheDocument();
+    expect(eventCategory).toBeInTheDocument();
+  });
+
+  it('달력에 1월 1일(신정)이 공휴일로 표시되는지 확인한다', async () => {
+    vi.setSystemTime(new Date('2024-01-01'));
+    renderApp();
+
+    const HAPPY_NEW_YEAR = await screen.findByText(/신정/);
+    expect(HAPPY_NEW_YEAR).toBeInTheDocument();
+  });
 });
 
 describe('검색 기능', () => {
-  it('검색 결과가 없으면, "검색 결과가 없습니다."가 표시되어야 한다.', async () => {});
+  it('검색 결과가 없으면, "검색 결과가 없습니다."가 표시되어야 한다.', async () => {
+    vi.setSystemTime(new Date('2024-10-14'));
+    renderApp();
 
-  it("'팀 회의'를 검색하면 해당 제목을 가진 일정이 리스트에 노출된다", async () => {});
+    const eventList = screen.getByTestId(/event-list/i);
+    const eventTitle = await within(eventList).findByText(/기존 회의/i);
 
-  it('검색어를 지우면 모든 일정이 다시 표시되어야 한다', async () => {});
+    expect(eventTitle).toBeInTheDocument();
+
+    const searchInput = screen.getByLabelText(/일정 검색/i);
+    await userEvent.type(searchInput, '크크루삥뽕');
+
+    const emptyEventText = await screen.findByText(/검색 결과가 없습니다/i);
+    expect(emptyEventText).toBeInTheDocument();
+    expect(eventTitle).not.toBeInTheDocument();
+  });
+
+  it("'응애'를 검색하면 해당 제목을 가진 일정이 리스트에 노출된다", async () => {
+    vi.setSystemTime(new Date('2024-10-14'));
+    renderApp();
+
+    const eventList = screen.getByTestId(/event-list/i);
+    const existingEventTitle = await within(eventList).findByText(/기존 회의/i);
+    expect(existingEventTitle).toBeInTheDocument();
+
+    const titleInput: HTMLInputElement = screen.getByLabelText(/제목/i);
+    const dateInput: HTMLInputElement = screen.getByLabelText(/날짜/i);
+    const startTimeInput: HTMLInputElement = screen.getByLabelText(/시작 시간/i);
+    const endTimeInput: HTMLInputElement = screen.getByLabelText(/종료 시간/i);
+    const descriptionInput: HTMLInputElement = screen.getByLabelText(/설명/i);
+    const locationInput: HTMLInputElement = screen.getByLabelText(/위치/i);
+    const categorySelect: HTMLSelectElement = screen.getByLabelText(/카테고리/i);
+    const notificationTimeSelect: HTMLSelectElement = screen.getByLabelText(/알림 설정/i);
+    const repeatTypeSelect: HTMLSelectElement = screen.getByLabelText(/반복 유형/i);
+    const repeatIntervalInput: HTMLInputElement = screen.getByLabelText(/반복 간격/i);
+    const repeatEndTimeInput: HTMLInputElement = screen.getByLabelText(/반복 종료일/i);
+
+    await userEvent.type(titleInput, '응애');
+    await userEvent.type(dateInput, '2024-10-05');
+    await userEvent.type(startTimeInput, '13:00');
+    await userEvent.type(endTimeInput, '14:00');
+    await userEvent.type(descriptionInput, '나 테스트 못해');
+    await userEvent.type(locationInput, '유모차안');
+    await userEvent.selectOptions(categorySelect, '개인');
+    await userEvent.selectOptions(notificationTimeSelect, '10');
+    await userEvent.selectOptions(repeatTypeSelect, 'daily');
+    await userEvent.type(repeatIntervalInput, '10');
+    await userEvent.type(repeatEndTimeInput, '2024-11-05');
+
+    const addEventButton = screen.getByRole('button', { name: /일정 추가/i });
+    await userEvent.click(addEventButton);
+
+    const searchInput = screen.getByLabelText(/일정 검색/i);
+    await userEvent.type(searchInput, '응애');
+
+    const eventTitle = await within(eventList).findByText(/응애/i);
+    const eventDate = await within(eventList).findByText(/2024-10-05/i);
+    const eventStartTime = await within(eventList).findByText(/13:00 - 14:00/i);
+    const eventDescription = await within(eventList).findByText(/나 테스트 못해/i);
+    const eventLocation = await within(eventList).findByText(/유모차안/i);
+    const eventCategory = await within(eventList).findByText(/카테고리: 개인/i);
+
+    expect(existingEventTitle).not.toBeInTheDocument();
+
+    expect(eventTitle).toBeInTheDocument();
+    expect(eventDate).toBeInTheDocument();
+    expect(eventStartTime).toBeInTheDocument();
+    expect(eventDescription).toBeInTheDocument();
+    expect(eventLocation).toBeInTheDocument();
+    expect(eventCategory).toBeInTheDocument();
+  });
+
+  it('검색어를 지우면 모든 일정이 다시 표시되어야 한다', async () => {
+    vi.setSystemTime(new Date('2024-10-14'));
+    renderApp();
+
+    const eventList = screen.getByTestId(/event-list/i);
+    const existingEventTitle = await within(eventList).findByText(/기존 회의/i);
+    expect(existingEventTitle).toBeInTheDocument();
+
+    const titleInput: HTMLInputElement = screen.getByLabelText(/제목/i);
+    const dateInput: HTMLInputElement = screen.getByLabelText(/날짜/i);
+    const startTimeInput: HTMLInputElement = screen.getByLabelText(/시작 시간/i);
+    const endTimeInput: HTMLInputElement = screen.getByLabelText(/종료 시간/i);
+    const descriptionInput: HTMLInputElement = screen.getByLabelText(/설명/i);
+    const locationInput: HTMLInputElement = screen.getByLabelText(/위치/i);
+    const categorySelect: HTMLSelectElement = screen.getByLabelText(/카테고리/i);
+
+    await userEvent.type(titleInput, '응애');
+    await userEvent.type(dateInput, '2024-10-05');
+    await userEvent.type(startTimeInput, '13:00');
+    await userEvent.type(endTimeInput, '14:00');
+    await userEvent.type(descriptionInput, '나 테스트 못해');
+    await userEvent.type(locationInput, '유모차안');
+    await userEvent.selectOptions(categorySelect, '개인');
+
+    const addEventButton = screen.getByRole('button', { name: /일정 추가/i });
+    await userEvent.click(addEventButton);
+
+    const searchInput: HTMLInputElement = screen.getByLabelText(/일정 검색/i);
+    await userEvent.type(searchInput, '응애');
+
+    const eventTitle = await within(eventList).findByText(/응애/i);
+
+    expect(existingEventTitle).not.toBeInTheDocument();
+    expect(eventTitle).toBeInTheDocument();
+
+    await userEvent.clear(searchInput);
+
+    await waitFor(() => {
+      expect(within(eventList).getByText(/응애/i)).toBeInTheDocument();
+      expect(within(eventList).getByText(/기존 회의/i)).toBeInTheDocument();
+    });
+  });
 });
 
 describe('일정 충돌', () => {
-  it('겹치는 시간에 새 일정을 추가할 때 경고가 표시된다', async () => {});
+  it('겹치는 시간에 새 일정을 추가할 때 경고가 표시된다', async () => {
+    renderApp();
 
-  it('기존 일정의 시간을 수정하여 충돌이 발생하면 경고가 노출된다', async () => {});
+    const titleInput: HTMLInputElement = screen.getByLabelText(/제목/i);
+    const dateInput: HTMLInputElement = screen.getByLabelText(/날짜/i);
+    const startTimeInput: HTMLInputElement = screen.getByLabelText(/시작 시간/i);
+    const endTimeInput: HTMLInputElement = screen.getByLabelText(/종료 시간/i);
+    const descriptionInput: HTMLInputElement = screen.getByLabelText(/설명/i);
+    const locationInput: HTMLInputElement = screen.getByLabelText(/위치/i);
+    const categorySelect: HTMLSelectElement = screen.getByLabelText(/카테고리/i);
+
+    await userEvent.type(titleInput, '응애');
+    await userEvent.type(dateInput, '2024-10-15');
+    await userEvent.type(startTimeInput, '09:00');
+    await userEvent.type(endTimeInput, '10:00');
+    await userEvent.type(descriptionInput, '나 테스트 못해');
+    await userEvent.type(locationInput, '유모차안');
+    await userEvent.selectOptions(categorySelect, '개인');
+
+    const addEventButton = screen.getByRole('button', { name: /일정 추가/i });
+    await userEvent.click(addEventButton);
+
+    const overlapEventDialog = await screen.findByText(/일정 겹침 경고/i);
+    expect(overlapEventDialog).toBeInTheDocument();
+  });
+
+  it('기존 일정의 시간을 수정하여 충돌이 발생하면 경고가 노출된다', async () => {
+    renderApp();
+
+    const titleInput: HTMLInputElement = screen.getByLabelText(/제목/i);
+    const dateInput: HTMLInputElement = screen.getByLabelText(/날짜/i);
+    const startTimeInput: HTMLInputElement = screen.getByLabelText(/시작 시간/i);
+    const endTimeInput: HTMLInputElement = screen.getByLabelText(/종료 시간/i);
+    const descriptionInput: HTMLInputElement = screen.getByLabelText(/설명/i);
+    const locationInput: HTMLInputElement = screen.getByLabelText(/위치/i);
+    const categorySelect: HTMLSelectElement = screen.getByLabelText(/카테고리/i);
+
+    await userEvent.type(titleInput, '응애');
+    await userEvent.type(dateInput, '2024-10-05');
+    await userEvent.type(startTimeInput, '13:00');
+    await userEvent.type(endTimeInput, '14:00');
+    await userEvent.type(descriptionInput, '나 테스트 못해');
+    await userEvent.type(locationInput, '유모차안');
+    await userEvent.selectOptions(categorySelect, '개인');
+
+    const addEventButton = screen.getByRole('button', { name: /일정 추가/i });
+    await userEvent.click(addEventButton);
+
+    const eventList = screen.getByTestId(/event-list/i);
+
+    const eventTitle = await within(eventList).findByText(/응애/i);
+    expect(eventTitle).toBeInTheDocument();
+
+    const editButton = await within(eventList).findAllByLabelText(/Edit event/i);
+    await userEvent.click(editButton[1]);
+
+    await userEvent.clear(titleInput);
+    await userEvent.type(titleInput, '응애 밥줘');
+
+    const registUpdateButton = screen.getByRole('button', { name: /일정 수정/i });
+    await userEvent.click(registUpdateButton);
+
+    expect(eventTitle.textContent).toBe('응애 밥줘');
+  });
 });
 
-it('notificationTime을 10으로 하면 지정 시간 10분 전 알람 텍스트가 노출된다', async () => {});
+it('notificationTime을 10으로 하면 지정 시간 10분 전 알람 텍스트가 노출된다', async () => {
+  vi.setSystemTime(new Date('2024-10-15T08:50'));
+  renderApp();
+
+  const eventList = screen.getByTestId(/event-list/i);
+
+  const eventRepeatInterval = await within(eventList).findByText(/알림: 10분 전/i);
+  expect(eventRepeatInterval).toBeInTheDocument();
+
+  const notificationAlarm = await screen.findByText(/10분 후 기존 회의 일정이 시작됩니다/i);
+  expect(notificationAlarm).toBeInTheDocument();
+});

--- a/src/__tests__/unit/easy.dateUtils.spec.ts
+++ b/src/__tests__/unit/easy.dateUtils.spec.ts
@@ -140,7 +140,6 @@ describe('getWeekDates', () => {
 describe('getWeeksAtMonth', () => {
   it('2024년 7월 1일의 올바른 주 정보를 반환해야 한다', () => {
     const weeksAtMonth = getWeeksAtMonth(new Date('2024-07-01'));
-    console.log(weeksAtMonth);
     expect(weeksAtMonth).toEqual([
       [null, 1, 2, 3, 4, 5, 6],
       [7, 8, 9, 10, 11, 12, 13],

--- a/src/__tests__/unit/easy.dateUtils.spec.ts
+++ b/src/__tests__/unit/easy.dateUtils.spec.ts
@@ -287,23 +287,50 @@ describe('isDateInRange', () => {
 });
 
 describe('fillZero', () => {
-  test("5를 2자리로 변환하면 '05'를 반환한다", () => {});
+  test("5를 2자리로 변환하면 '05'를 반환한다", () => {
+    const fillZeroText = fillZero(5, 2);
+    expect(fillZeroText).toBe('05');
+  });
 
-  test("10을 2자리로 변환하면 '10'을 반환한다", () => {});
+  test("10을 2자리로 변환하면 '10'을 반환한다", () => {
+    const fillZeroText = fillZero(10, 2);
+    expect(fillZeroText).toBe('10');
+  });
 
-  test("3을 3자리로 변환하면 '003'을 반환한다", () => {});
+  test("3을 3자리로 변환하면 '003'을 반환한다", () => {
+    const fillZeroText = fillZero(3, 3);
+    expect(fillZeroText).toBe('003');
+  });
 
-  test("100을 2자리로 변환하면 '100'을 반환한다", () => {});
+  test("100을 2자리로 변환하면 '100'을 반환한다", () => {
+    const fillZeroText = fillZero(100, 2);
+    expect(fillZeroText).toBe('100');
+  });
 
-  test("0을 2자리로 변환하면 '00'을 반환한다", () => {});
+  test("0을 2자리로 변환하면 '00'을 반환한다", () => {
+    const fillZeroText = fillZero(0, 2);
+    expect(fillZeroText).toBe('00');
+  });
 
-  test("1을 5자리로 변환하면 '00001'을 반환한다", () => {});
+  test("1을 5자리로 변환하면 '00001'을 반환한다", () => {
+    const fillZeroText = fillZero(1, 5);
+    expect(fillZeroText).toBe('00001');
+  });
 
-  test("소수점이 있는 3.14를 5자리로 변환하면 '03.14'를 반환한다", () => {});
+  test("소수점이 있는 3.14를 5자리로 변환하면 '03.14'를 반환한다", () => {
+    const fillZeroText = fillZero(3.14, 5);
+    expect(fillZeroText).toBe('03.14');
+  });
 
-  test('size 파라미터를 생략하면 기본값 2를 사용한다', () => {});
+  test('size 파라미터를 생략하면 기본값 2를 사용한다', () => {
+    const fillZeroText = fillZero(5);
+    expect(fillZeroText).toBe('05');
+  });
 
-  test('value가 지정된 size보다 큰 자릿수를 가지면 원래 값을 그대로 반환한다', () => {});
+  test('value가 지정된 size보다 큰 자릿수를 가지면 원래 값을 그대로 반환한다', () => {
+    const fillZeroText = fillZero(1000, 2);
+    expect(fillZeroText).toBe('1000');
+  });
 });
 
 describe('formatDate', () => {

--- a/src/__tests__/unit/easy.dateUtils.spec.ts
+++ b/src/__tests__/unit/easy.dateUtils.spec.ts
@@ -12,13 +12,25 @@ import {
 } from '../../utils/dateUtils';
 
 describe('getDaysInMonth', () => {
-  it('1월은 31일 수를 반환한다', () => {});
+  it('1월은 31일 수를 반환한다', () => {
+    const daysInMonth = getDaysInMonth(2024, 1);
+    expect(daysInMonth).toBe(31);
+  });
 
-  it('4월은 30일 일수를 반환한다', () => {});
+  it('4월은 30일 일수를 반환한다', () => {
+    const daysInMonth = getDaysInMonth(2024, 4);
+    expect(daysInMonth).toBe(30);
+  });
 
-  it('윤년의 2월에 대해 29일을 반환한다', () => {});
+  it('윤년의 2월에 대해 29일을 반환한다', () => {
+    const daysInMonth = getDaysInMonth(2024, 2);
+    expect(daysInMonth).toBe(29);
+  });
 
-  it('평년의 2월에 대해 28일을 반환한다', () => {});
+  it('평년의 2월에 대해 28일을 반환한다', () => {
+    const daysInMonth = getDaysInMonth(2023, 2);
+    expect(daysInMonth).toBe(28);
+  });
 
   it('유효하지 않은 월에 대해 적절히 처리한다', () => {});
 });

--- a/src/__tests__/unit/easy.dateUtils.spec.ts
+++ b/src/__tests__/unit/easy.dateUtils.spec.ts
@@ -11,7 +11,7 @@ import {
   isDateInRange,
 } from '../../utils/dateUtils';
 
-describe('test', () => {
+describe('getDaysInMonth', () => {
   it('1월은 31일 수를 반환한다', () => {
     const daysInMonth = getDaysInMonth(2024, 1);
     expect(daysInMonth).toBe(31);
@@ -32,7 +32,16 @@ describe('test', () => {
     expect(daysInMonth).toBe(28);
   });
 
-  it('유효하지 않은 월에 대해 적절히 처리한다', () => {});
+  it('유효하지 않은 월에 대해 적절히 처리한다(이전 해나 다음해의 일수를 반환한다)', () => {
+    const daysInMonthArray = [
+      getDaysInMonth(2023, 0),
+      getDaysInMonth(2023, -1),
+      getDaysInMonth(2023, 13),
+      getDaysInMonth(2023, 15),
+    ];
+
+    expect(daysInMonthArray).toEqual([31, 30, 31, 31]);
+  });
 });
 
 describe('getWeekDates', () => {

--- a/src/__tests__/unit/easy.dateUtils.spec.ts
+++ b/src/__tests__/unit/easy.dateUtils.spec.ts
@@ -143,13 +143,73 @@ describe('getWeeksAtMonth', () => {
 });
 
 describe('getEventsForDay', () => {
-  it('특정 날짜(1일)에 해당하는 이벤트만 정확히 반환한다', () => {});
+  const events: Event[] = [
+    {
+      id: '2b7545a6-ebee-426c-b906-2329bc8d62bd',
+      title: '팀 회의',
+      date: '2024-11-01',
+      startTime: '10:00',
+      endTime: '11:00',
+      description: '주간 팀 미팅',
+      location: '회의실 A',
+      category: '업무',
+      repeat: {
+        type: 'none',
+        interval: 0,
+      },
+      notificationTime: 1,
+    },
+    {
+      id: '09702fb3-a478-40b3-905e-9ab3c8849dcd',
+      title: '점심 약속',
+      date: '2024-12-31',
+      startTime: '12:30',
+      endTime: '13:30',
+      description: '동료와 점심 식사',
+      location: '회사 근처 식당',
+      category: '개인',
+      repeat: {
+        type: 'none',
+        interval: 0,
+      },
+      notificationTime: 1,
+    },
+  ];
+  it('특정 날짜(1일)에 해당하는 이벤트만 정확히 반환한다', () => {
+    const eventsForDay = getEventsForDay(events, 1);
+    expect(eventsForDay).toEqual([
+      {
+        id: '2b7545a6-ebee-426c-b906-2329bc8d62bd',
+        title: '팀 회의',
+        date: '2024-11-01',
+        startTime: '10:00',
+        endTime: '11:00',
+        description: '주간 팀 미팅',
+        location: '회의실 A',
+        category: '업무',
+        repeat: {
+          type: 'none',
+          interval: 0,
+        },
+        notificationTime: 1,
+      },
+    ]);
+  });
 
-  it('해당 날짜에 이벤트가 없을 경우 빈 배열을 반환한다', () => {});
+  it('해당 날짜에 이벤트가 없을 경우 빈 배열을 반환한다', () => {
+    const eventsForDay = getEventsForDay(events, 22);
+    expect(eventsForDay).toEqual([]);
+  });
 
-  it('날짜가 0일 경우 빈 배열을 반환한다', () => {});
+  it('날짜가 0일 경우 빈 배열을 반환한다', () => {
+    const eventsForDay = getEventsForDay(events, 0);
+    expect(eventsForDay).toEqual([]);
+  });
 
-  it('날짜가 32일 이상인 경우 빈 배열을 반환한다', () => {});
+  it('날짜가 32일 이상인 경우 빈 배열을 반환한다', () => {
+    const eventsForDay = getEventsForDay(events, 32);
+    expect(eventsForDay).toEqual([]);
+  });
 });
 
 describe('formatWeek', () => {

--- a/src/__tests__/unit/easy.dateUtils.spec.ts
+++ b/src/__tests__/unit/easy.dateUtils.spec.ts
@@ -213,21 +213,42 @@ describe('getEventsForDay', () => {
 });
 
 describe('formatWeek', () => {
-  it('월의 중간 날짜에 대해 올바른 주 정보를 반환한다', () => {});
+  it('월의 중간 날짜에 대해 올바른 주 정보를 반환한다', () => {
+    const weekInfo = formatWeek(new Date('2024-11-15'));
+    expect(weekInfo).toBe('2024년 11월 2주');
+  });
 
-  it('월의 첫 주에 대해 올바른 주 정보를 반환한다', () => {});
+  it('월의 첫 주에 대해 올바른 주 정보를 반환한다', () => {
+    const weekInfo = formatWeek(new Date('2024-11-04'));
+    expect(weekInfo).toBe('2024년 11월 1주');
+  });
 
-  it('월의 마지막 주에 대해 올바른 주 정보를 반환한다', () => {});
+  it('월의 마지막 주에 대해 올바른 주 정보를 반환한다', () => {
+    const weekInfo = formatWeek(new Date('2024-11-30'));
+    expect(weekInfo).toBe('2024년 11월 4주');
+  });
 
-  it('연도가 바뀌는 주에 대해 올바른 주 정보를 반환한다', () => {});
+  it('연도가 바뀌는 주에 대해 올바른 주 정보를 반환한다', () => {
+    const weekInfo = formatWeek(new Date('2025-01-01'));
+    expect(weekInfo).toBe('2025년 1월 1주');
+  });
 
-  it('윤년 2월의 마지막 주에 대해 올바른 주 정보를 반환한다', () => {});
+  it('윤년 2월의 마지막 주에 대해 올바른 주 정보를 반환한다', () => {
+    const weekInfo = formatWeek(new Date('2024-02-29'));
+    expect(weekInfo).toBe('2024년 2월 5주');
+  });
 
-  it('평년 2월의 마지막 주에 대해 올바른 주 정보를 반환한다', () => {});
+  it('평년 2월의 마지막 주에 대해 올바른 주 정보를 반환한다', () => {
+    const weekInfo = formatWeek(new Date('2025-02-28'));
+    expect(weekInfo).toBe('2025년 2월 4주');
+  });
 });
 
 describe('formatMonth', () => {
-  it("2024년 7월 10일을 '2024년 7월'로 반환한다", () => {});
+  it("2024년 7월 10일을 '2024년 7월'로 반환한다", () => {
+    const monthInfo = formatMonth(new Date('2024-07-10'));
+    expect(monthInfo).toBe('2024년 7월');
+  });
 });
 
 describe('isDateInRange', () => {

--- a/src/__tests__/unit/easy.dateUtils.spec.ts
+++ b/src/__tests__/unit/easy.dateUtils.spec.ts
@@ -255,17 +255,35 @@ describe('isDateInRange', () => {
   const rangeStart = new Date('2024-07-01');
   const rangeEnd = new Date('2024-07-31');
 
-  it('범위 내의 날짜 2024-07-10에 대해 true를 반환한다', () => {});
+  it('범위 내의 날짜 2024-07-10에 대해 true를 반환한다', () => {
+    const isWithinRange = isDateInRange(new Date('2024-07-10'), rangeStart, rangeEnd);
+    expect(isWithinRange).toBe(true);
+  });
 
-  it('범위의 시작일 2024-07-01에 대해 true를 반환한다', () => {});
+  it('범위의 시작일 2024-07-01에 대해 true를 반환한다', () => {
+    const isWithinRange = isDateInRange(new Date('2024-07-01'), rangeStart, rangeEnd);
+    expect(isWithinRange).toBe(true);
+  });
 
-  it('범위의 종료일 2024-07-31에 대해 true를 반환한다', () => {});
+  it('범위의 종료일 2024-07-31에 대해 true를 반환한다', () => {
+    const isWithinRange = isDateInRange(new Date('2024-07-31'), rangeStart, rangeEnd);
+    expect(isWithinRange).toBe(true);
+  });
 
-  it('범위 이전의 날짜 2024-06-30에 대해 false를 반환한다', () => {});
+  it('범위 이전의 날짜 2024-06-30에 대해 false를 반환한다', () => {
+    const isWithinRange = isDateInRange(new Date('2024-06-30'), rangeStart, rangeEnd);
+    expect(isWithinRange).toBe(false);
+  });
 
-  it('범위 이후의 날짜 2024-08-01에 대해 false를 반환한다', () => {});
+  it('범위 이후의 날짜 2024-08-01에 대해 false를 반환한다', () => {
+    const isWithinRange = isDateInRange(new Date('2024-08-01'), rangeStart, rangeEnd);
+    expect(isWithinRange).toBe(false);
+  });
 
-  it('시작일이 종료일보다 늦은 경우 모든 날짜에 대해 false를 반환한다', () => {});
+  it('시작일이 종료일보다 늦은 경우 모든 날짜에 대해 false를 반환한다', () => {
+    const isWithinRange = isDateInRange(new Date('2024-07-10'), rangeEnd, rangeStart);
+    expect(isWithinRange).toBe(false);
+  });
 });
 
 describe('fillZero', () => {

--- a/src/__tests__/unit/easy.dateUtils.spec.ts
+++ b/src/__tests__/unit/easy.dateUtils.spec.ts
@@ -334,11 +334,23 @@ describe('fillZero', () => {
 });
 
 describe('formatDate', () => {
-  it('날짜를 YYYY-MM-DD 형식으로 포맷팅한다', () => {});
+  it('날짜를 YYYY-MM-DD 형식으로 포맷팅한다', () => {
+    const formatDateText = formatDate(new Date('2024-11-04'));
+    expect(formatDateText).toBe('2024-11-04');
+  });
 
-  it('day 파라미터가 제공되면 해당 일자로 포맷팅한다', () => {});
+  it('day 파라미터가 제공되면 해당 일자로 포맷팅한다', () => {
+    const formatDateText = formatDate(new Date('2024-11-04'), 20);
+    expect(formatDateText).toBe('2024-11-20');
+  });
 
-  it('월이 한 자리 수일 때 앞에 0을 붙여 포맷팅한다', () => {});
+  it('월이 한 자리 수일 때 앞에 0을 붙여 포맷팅한다', () => {
+    const formatDateText = formatDate(new Date('2024-8-04'));
+    expect(formatDateText).toBe('2024-08-04');
+  });
 
-  it('일이 한 자리 수일 때 앞에 0을 붙여 포맷팅한다', () => {});
+  it('일이 한 자리 수일 때 앞에 0을 붙여 포맷팅한다', () => {
+    const formatDateText = formatDate(new Date('2024-11-4'));
+    expect(formatDateText).toBe('2024-11-04');
+  });
 });

--- a/src/__tests__/unit/easy.dateUtils.spec.ts
+++ b/src/__tests__/unit/easy.dateUtils.spec.ts
@@ -11,7 +11,7 @@ import {
   isDateInRange,
 } from '../../utils/dateUtils';
 
-describe('getDaysInMonth', () => {
+describe('test', () => {
   it('1월은 31일 수를 반환한다', () => {
     const daysInMonth = getDaysInMonth(2024, 1);
     expect(daysInMonth).toBe(31);
@@ -36,23 +36,110 @@ describe('getDaysInMonth', () => {
 });
 
 describe('getWeekDates', () => {
-  it('주중의 날짜(수요일)에 대해 올바른 주의 날짜들을 반환한다', () => {});
+  it('주중의 날짜(수요일)에 대해 올바른 주의 날짜들을 반환한다', () => {
+    const weekDates = getWeekDates(new Date('2024-11-06'));
+    expect(weekDates).toEqual([
+      new Date('2024-11-03'),
+      new Date('2024-11-04'),
+      new Date('2024-11-05'),
+      new Date('2024-11-06'),
+      new Date('2024-11-07'),
+      new Date('2024-11-08'),
+      new Date('2024-11-09'),
+    ]);
+  });
 
-  it('주의 시작(월요일)에 대해 올바른 주의 날짜들을 반환한다', () => {});
+  it('주의 시작(일요일)에 대해 올바른 주의 날짜들을 반환한다', () => {
+    const weekDates = getWeekDates(new Date('2024-11-03'));
+    expect(weekDates).toEqual([
+      new Date('2024-11-03'),
+      new Date('2024-11-04'),
+      new Date('2024-11-05'),
+      new Date('2024-11-06'),
+      new Date('2024-11-07'),
+      new Date('2024-11-08'),
+      new Date('2024-11-09'),
+    ]);
+  });
 
-  it('주의 끝(일요일)에 대해 올바른 주의 날짜들을 반환한다', () => {});
+  it('주의 끝(토요일)에 대해 올바른 주의 날짜들을 반환한다', () => {
+    const weekDates = getWeekDates(new Date('2024-11-09'));
+    expect(weekDates).toEqual([
+      new Date('2024-11-03'),
+      new Date('2024-11-04'),
+      new Date('2024-11-05'),
+      new Date('2024-11-06'),
+      new Date('2024-11-07'),
+      new Date('2024-11-08'),
+      new Date('2024-11-09'),
+    ]);
+  });
 
-  it('연도를 넘어가는 주의 날짜를 정확히 처리한다 (연말)', () => {});
+  it('연도를 넘어가는 주의 날짜를 정확히 처리한다 (연말)', () => {
+    const weekDates = getWeekDates(new Date('2024-12-31'));
+    expect(weekDates).toEqual([
+      new Date('2024-12-29'),
+      new Date('2024-12-30'),
+      new Date('2024-12-31'),
+      new Date('2025-01-01'),
+      new Date('2025-01-02'),
+      new Date('2025-01-03'),
+      new Date('2025-01-04'),
+    ]);
+  });
 
-  it('연도를 넘어가는 주의 날짜를 정확히 처리한다 (연초)', () => {});
+  it('연도를 넘어가는 주의 날짜를 정확히 처리한다 (연초)', () => {
+    const weekDates = getWeekDates(new Date('2025-01-01'));
+    expect(weekDates).toEqual([
+      new Date('2024-12-29'),
+      new Date('2024-12-30'),
+      new Date('2024-12-31'),
+      new Date('2025-01-01'),
+      new Date('2025-01-02'),
+      new Date('2025-01-03'),
+      new Date('2025-01-04'),
+    ]);
+  });
 
-  it('윤년의 2월 29일을 포함한 주를 올바르게 처리한다', () => {});
+  it('윤년의 2월 29일을 포함한 주를 올바르게 처리한다', () => {
+    const weekDates = getWeekDates(new Date('2024-02-29'));
+    expect(weekDates).toEqual([
+      new Date('2024-02-25'),
+      new Date('2024-02-26'),
+      new Date('2024-02-27'),
+      new Date('2024-02-28'),
+      new Date('2024-02-29'),
+      new Date('2024-03-01'),
+      new Date('2024-03-02'),
+    ]);
+  });
 
-  it('월의 마지막 날짜를 포함한 주를 올바르게 처리한다', () => {});
+  it('월의 마지막 날짜를 포함한 주를 올바르게 처리한다', () => {
+    const weekDates = getWeekDates(new Date('2024-11-30'));
+    expect(weekDates).toEqual([
+      new Date('2024-11-24'),
+      new Date('2024-11-25'),
+      new Date('2024-11-26'),
+      new Date('2024-11-27'),
+      new Date('2024-11-28'),
+      new Date('2024-11-29'),
+      new Date('2024-11-30'),
+    ]);
+  });
 });
 
 describe('getWeeksAtMonth', () => {
-  it('2024년 7월 1일의 올바른 주 정보를 반환해야 한다', () => {});
+  it('2024년 7월 1일의 올바른 주 정보를 반환해야 한다', () => {
+    const weeksAtMonth = getWeeksAtMonth(new Date('2024-07-01'));
+    console.log(weeksAtMonth);
+    expect(weeksAtMonth).toEqual([
+      [null, 1, 2, 3, 4, 5, 6],
+      [7, 8, 9, 10, 11, 12, 13],
+      [14, 15, 16, 17, 18, 19, 20],
+      [21, 22, 23, 24, 25, 26, 27],
+      [28, 29, 30, 31, null, null, null],
+    ]);
+  });
 });
 
 describe('getEventsForDay', () => {

--- a/src/__tests__/unit/easy.eventOverlap.spec.ts
+++ b/src/__tests__/unit/easy.eventOverlap.spec.ts
@@ -179,7 +179,232 @@ describe('isOverlapping', () => {
 });
 
 describe('findOverlappingEvents', () => {
-  it('새 이벤트와 겹치는 모든 이벤트를 반환한다', () => {});
+  it('새 이벤트와 겹치는 모든 이벤트를 반환한다', () => {
+    const events: Event[] = [
+      {
+        id: '2b7545a6-ebee-426c-b906-2329bc8d62bd',
+        title: '팀 회의',
+        date: '2024-11-25',
+        startTime: '10:00',
+        endTime: '11:00',
+        description: '주간 팀 미팅',
+        location: '회의실 A',
+        category: '업무',
+        repeat: {
+          type: 'none',
+          interval: 0,
+        },
+        notificationTime: 1,
+      },
+      {
+        id: '09702fb3-a478-40b3-905e-9ab3c8849dcd',
+        title: '점심 약속',
+        date: '2024-11-25',
+        startTime: '12:30',
+        endTime: '13:30',
+        description: '동료와 점심 식사',
+        location: '회사 근처 식당',
+        category: '개인',
+        repeat: {
+          type: 'none',
+          interval: 0,
+        },
+        notificationTime: 1,
+      },
+      {
+        id: 'da3ca408-836a-4d98-b67a-ca389d07552b',
+        title: '프로젝트 마감',
+        date: '2024-11-26',
+        startTime: '09:00',
+        endTime: '18:00',
+        description: '분기별 프로젝트 마감',
+        location: '사무실',
+        category: '업무',
+        repeat: {
+          type: 'none',
+          interval: 0,
+        },
+        notificationTime: 1,
+      },
+      {
+        id: 'dac62941-69e5-4ec0-98cc-24c2a79a7f81',
+        title: '생일 파티',
+        date: '2024-11-27',
+        startTime: '19:00',
+        endTime: '22:00',
+        description: '친구 생일 축하',
+        location: '친구 집',
+        category: '개인',
+        repeat: {
+          type: 'none',
+          interval: 0,
+        },
+        notificationTime: 1,
+      },
+      {
+        id: '80d85368-b4a4-47b3-b959-25171d49371f',
+        title: '운동',
+        date: '2024-11-29',
+        startTime: '18:00',
+        endTime: '19:00',
+        description: '주간 운동',
+        location: '헬스장',
+        category: '개인',
+        repeat: {
+          type: 'none',
+          interval: 0,
+        },
+        notificationTime: 1,
+      },
+    ];
 
-  it('겹치는 이벤트가 없으면 빈 배열을 반환한다', () => {});
+    const newEvent: Event = {
+      id: 'da3ca408-836a-4d98-b67a-ca389d07552b',
+      title: '프로젝트 마감',
+      date: '2024-11-25',
+      startTime: '09:00',
+      endTime: '15:00',
+      description: '분기별 프로젝트 마감',
+      location: '사무실',
+      category: '업무',
+      repeat: {
+        type: 'none',
+        interval: 0,
+      },
+      notificationTime: 1,
+    };
+
+    const getOverlapEvent = findOverlappingEvents(newEvent, events);
+    expect(getOverlapEvent).toEqual([
+      {
+        id: '2b7545a6-ebee-426c-b906-2329bc8d62bd',
+        title: '팀 회의',
+        date: '2024-11-25',
+        startTime: '10:00',
+        endTime: '11:00',
+        description: '주간 팀 미팅',
+        location: '회의실 A',
+        category: '업무',
+        repeat: {
+          type: 'none',
+          interval: 0,
+        },
+        notificationTime: 1,
+      },
+      {
+        id: '09702fb3-a478-40b3-905e-9ab3c8849dcd',
+        title: '점심 약속',
+        date: '2024-11-25',
+        startTime: '12:30',
+        endTime: '13:30',
+        description: '동료와 점심 식사',
+        location: '회사 근처 식당',
+        category: '개인',
+        repeat: {
+          type: 'none',
+          interval: 0,
+        },
+        notificationTime: 1,
+      },
+    ]);
+  });
+
+  it('겹치는 이벤트가 없으면 빈 배열을 반환한다', () => {
+    const events: Event[] = [
+      {
+        id: '2b7545a6-ebee-426c-b906-2329bc8d62bd',
+        title: '팀 회의',
+        date: '2024-11-25',
+        startTime: '10:00',
+        endTime: '11:00',
+        description: '주간 팀 미팅',
+        location: '회의실 A',
+        category: '업무',
+        repeat: {
+          type: 'none',
+          interval: 0,
+        },
+        notificationTime: 1,
+      },
+      {
+        id: '09702fb3-a478-40b3-905e-9ab3c8849dcd',
+        title: '점심 약속',
+        date: '2024-11-25',
+        startTime: '12:30',
+        endTime: '13:30',
+        description: '동료와 점심 식사',
+        location: '회사 근처 식당',
+        category: '개인',
+        repeat: {
+          type: 'none',
+          interval: 0,
+        },
+        notificationTime: 1,
+      },
+      {
+        id: 'da3ca408-836a-4d98-b67a-ca389d07552b',
+        title: '프로젝트 마감',
+        date: '2024-11-26',
+        startTime: '09:00',
+        endTime: '18:00',
+        description: '분기별 프로젝트 마감',
+        location: '사무실',
+        category: '업무',
+        repeat: {
+          type: 'none',
+          interval: 0,
+        },
+        notificationTime: 1,
+      },
+      {
+        id: 'dac62941-69e5-4ec0-98cc-24c2a79a7f81',
+        title: '생일 파티',
+        date: '2024-11-27',
+        startTime: '19:00',
+        endTime: '22:00',
+        description: '친구 생일 축하',
+        location: '친구 집',
+        category: '개인',
+        repeat: {
+          type: 'none',
+          interval: 0,
+        },
+        notificationTime: 1,
+      },
+      {
+        id: '80d85368-b4a4-47b3-b959-25171d49371f',
+        title: '운동',
+        date: '2024-11-29',
+        startTime: '18:00',
+        endTime: '19:00',
+        description: '주간 운동',
+        location: '헬스장',
+        category: '개인',
+        repeat: {
+          type: 'none',
+          interval: 0,
+        },
+        notificationTime: 1,
+      },
+    ];
+
+    const newEvent: Event = {
+      id: 'da3ca408-836a-4d98-b67a-ca389d07552b',
+      title: '프로젝트 마감',
+      date: '2024-11-25',
+      startTime: '19:00',
+      endTime: '22:00',
+      description: '분기별 프로젝트 마감',
+      location: '사무실',
+      category: '업무',
+      repeat: {
+        type: 'none',
+        interval: 0,
+      },
+      notificationTime: 1,
+    };
+
+    const getOverlapEvent = findOverlappingEvents(newEvent, events);
+    expect(getOverlapEvent).toEqual([]);
+  });
 });

--- a/src/__tests__/unit/easy.eventOverlap.spec.ts
+++ b/src/__tests__/unit/easy.eventOverlap.spec.ts
@@ -15,29 +15,107 @@ describe('parseDateTime', () => {
   it('잘못된 날짜 형식에 대해 Invalid Date를 반환한다', () => {
     const dateTime = parseDateTime('2024/09/01', '14:30');
     expect(dateTime.toString()).toBe('Invalid Date');
+    expect(dateTime).toEqual(new Date(''));
   });
 
   it('잘못된 시간 형식에 대해 Invalid Date를 반환한다', () => {
     const dateTime = parseDateTime('2024-09-01', '14-30');
     expect(dateTime.toString()).toBe('Invalid Date');
+    expect(dateTime).toEqual(new Date(''));
   });
 
   it('날짜 문자열이 비어있을 때 Invalid Date를 반환한다', () => {
     const dateTime = parseDateTime('', '14:30');
     expect(dateTime.toString()).toBe('Invalid Date');
+    expect(dateTime).toEqual(new Date(''));
   });
 });
 
 describe('convertEventToDateRange', () => {
-  it('일반적인 이벤트를 올바른 시작 및 종료 시간을 가진 객체로 변환한다', () => {});
+  it('일반적인 이벤트를 올바른 시작 및 종료 시간을 가진 객체로 변환한다', () => {
+    const eventTime = convertEventToDateRange({
+      id: '2b7545a6-ebee-426c-b906-2329bc8d62bd',
+      title: '팀 회의',
+      date: '2024-11-20',
+      startTime: '10:00',
+      endTime: '11:00',
+      description: '주간 팀 미팅',
+      location: '회의실 A',
+      category: '업무',
+      repeat: {
+        type: 'none',
+        interval: 0,
+      },
+      notificationTime: 1,
+    });
 
-  it('잘못된 날짜 형식의 이벤트에 대해 Invalid Date를 반환한다', () => {});
+    expect(eventTime).toEqual({
+      start: new Date('2024-11-20T10:00'),
+      end: new Date('2024-11-20T11:00'),
+    });
+  });
 
-  it('잘못된 시간 형식의 이벤트에 대해 Invalid Date를 반환한다', () => {});
+  it('잘못된 날짜 형식의 이벤트에 대해 Invalid Date를 반환한다', () => {
+    const eventTime = convertEventToDateRange({
+      id: '2b7545a6-ebee-426c-b906-2329bc8d62bd',
+      title: '팀 회의',
+      date: '2024/11/20',
+      startTime: '10:00',
+      endTime: '11:00',
+      description: '주간 팀 미팅',
+      location: '회의실 A',
+      category: '업무',
+      repeat: {
+        type: 'none',
+        interval: 0,
+      },
+      notificationTime: 1,
+    });
+    expect(eventTime.start.toString()).toBe('Invalid Date');
+    expect(eventTime.end.toString()).toBe('Invalid Date');
+    expect(eventTime).toEqual({
+      start: new Date(''),
+      end: new Date(''),
+    });
+  });
+
+  it('잘못된 시간 형식의 이벤트에 대해 Invalid Date를 반환한다', () => {
+    const eventTime = convertEventToDateRange({
+      id: '2b7545a6-ebee-426c-b906-2329bc8d62bd',
+      title: '팀 회의',
+      date: '2024-11-20',
+      startTime: '10-00',
+      endTime: '11-00',
+      description: '주간 팀 미팅',
+      location: '회의실 A',
+      category: '업무',
+      repeat: {
+        type: 'none',
+        interval: 0,
+      },
+      notificationTime: 1,
+    });
+    expect(eventTime.start.toString()).toBe('Invalid Date');
+    expect(eventTime.end.toString()).toBe('Invalid Date');
+    expect(eventTime).toEqual({
+      start: new Date(''),
+      end: new Date(''),
+    });
+  });
 });
 
 describe('isOverlapping', () => {
-  it('두 이벤트가 겹치는 경우 true를 반환한다', () => {});
+  it('두 이벤트가 겹치는 경우 true를 반환한다', () => {
+    // title: string;
+    // date: string;
+    // startTime: string;
+    // endTime: string;
+    // description: string;
+    // location: string;
+    // category: string;
+    // repeat: RepeatInfo;
+    // notificationTime: number;
+  });
 
   it('두 이벤트가 겹치지 않는 경우 false를 반환한다', () => {});
 });

--- a/src/__tests__/unit/easy.eventOverlap.spec.ts
+++ b/src/__tests__/unit/easy.eventOverlap.spec.ts
@@ -7,13 +7,25 @@ import {
 } from '../../utils/eventOverlap';
 
 describe('parseDateTime', () => {
-  it('2024-07-01 14:30을 정확한 Date 객체로 변환한다', () => {});
+  it('2024-07-01 14:30을 정확한 Date 객체로 변환한다', () => {
+    const dateTime = parseDateTime('2024-07-01', '14:30');
+    expect(dateTime).toEqual(new Date('2024-07-01T14:30'));
+  });
 
-  it('잘못된 날짜 형식에 대해 Invalid Date를 반환한다', () => {});
+  it('잘못된 날짜 형식에 대해 Invalid Date를 반환한다', () => {
+    const dateTime = parseDateTime('2024/09/01', '14:30');
+    expect(dateTime.toString()).toBe('Invalid Date');
+  });
 
-  it('잘못된 시간 형식에 대해 Invalid Date를 반환한다', () => {});
+  it('잘못된 시간 형식에 대해 Invalid Date를 반환한다', () => {
+    const dateTime = parseDateTime('2024-09-01', '14-30');
+    expect(dateTime.toString()).toBe('Invalid Date');
+  });
 
-  it('날짜 문자열이 비어있을 때 Invalid Date를 반환한다', () => {});
+  it('날짜 문자열이 비어있을 때 Invalid Date를 반환한다', () => {
+    const dateTime = parseDateTime('', '14:30');
+    expect(dateTime.toString()).toBe('Invalid Date');
+  });
 });
 
 describe('convertEventToDateRange', () => {

--- a/src/__tests__/unit/easy.eventOverlap.spec.ts
+++ b/src/__tests__/unit/easy.eventOverlap.spec.ts
@@ -106,18 +106,76 @@ describe('convertEventToDateRange', () => {
 
 describe('isOverlapping', () => {
   it('두 이벤트가 겹치는 경우 true를 반환한다', () => {
-    // title: string;
-    // date: string;
-    // startTime: string;
-    // endTime: string;
-    // description: string;
-    // location: string;
-    // category: string;
-    // repeat: RepeatInfo;
-    // notificationTime: number;
+    const event1: Event = {
+      id: '2b7545a6-ebee-426c-b906-2329bc8d62bd',
+      title: '팀 회의',
+      date: '2024-11-20',
+      startTime: '10:00',
+      endTime: '11:00',
+      description: '주간 팀 미팅',
+      location: '회의실 A',
+      category: '업무',
+      repeat: {
+        type: 'none',
+        interval: 0,
+      },
+      notificationTime: 1,
+    };
+
+    const event2: Event = {
+      id: '2b7545a6-ebee-426c-b906-2329bc8d62bd',
+      title: '팀 회의',
+      date: '2024-11-20',
+      startTime: '10:30',
+      endTime: '12:00',
+      description: '주간 팀 미팅',
+      location: '회의실 A',
+      category: '업무',
+      repeat: {
+        type: 'none',
+        interval: 0,
+      },
+      notificationTime: 1,
+    };
+    const isOverlap = isOverlapping(event1, event2);
+    expect(isOverlap).toBe(true);
   });
 
-  it('두 이벤트가 겹치지 않는 경우 false를 반환한다', () => {});
+  it('두 이벤트가 겹치지 않는 경우 false를 반환한다', () => {
+    const event1: Event = {
+      id: '2b7545a6-ebee-426c-b906-2329bc8d62bd',
+      title: '팀 회의',
+      date: '2024-11-20',
+      startTime: '10:00',
+      endTime: '11:00',
+      description: '주간 팀 미팅',
+      location: '회의실 A',
+      category: '업무',
+      repeat: {
+        type: 'none',
+        interval: 0,
+      },
+      notificationTime: 1,
+    };
+
+    const event2: Event = {
+      id: '2b7545a6-ebee-426c-b906-2329bc8d62bd',
+      title: '팀 회의',
+      date: '2024-11-20',
+      startTime: '11:30',
+      endTime: '12:30',
+      description: '주간 팀 미팅',
+      location: '회의실 A',
+      category: '업무',
+      repeat: {
+        type: 'none',
+        interval: 0,
+      },
+      notificationTime: 1,
+    };
+    const isOverlap = isOverlapping(event1, event2);
+    expect(isOverlap).toBe(false);
+  });
 });
 
 describe('findOverlappingEvents', () => {

--- a/src/__tests__/unit/easy.eventUtils.spec.ts
+++ b/src/__tests__/unit/easy.eventUtils.spec.ts
@@ -2,19 +2,310 @@ import { Event } from '../../types';
 import { getFilteredEvents } from '../../utils/eventUtils';
 
 describe('getFilteredEvents', () => {
-  it("검색어 '이벤트 2'에 맞는 이벤트만 반환한다", () => {});
+  const events: Event[] = [
+    {
+      id: 'a7f8d5e0-3f4b-4b8a-9e20-1f46a8c5e123',
+      title: '이벤트 2',
+      date: '2024-11-15',
+      startTime: '14:00',
+      endTime: '17:00',
+      description: 'Learn to cook Italian dishes',
+      location: 'Culinary Arts Studio',
+      category: 'Education',
+      repeat: { type: 'none', interval: 0 },
+      notificationTime: 45,
+    },
+    {
+      id: '5e3d9b2c-17c2-4c8e-8c2b-0f0c0d1f9e56',
+      title: 'Photography Walk',
+      date: '2024-07-02',
+      startTime: '08:00',
+      endTime: '10:30',
+      description: 'Explore urban landscapes through photography',
+      location: 'Central Park',
+      category: 'Hobby',
+      repeat: { type: 'monthly', interval: 1, endDate: '2025-06-18' },
+      notificationTime: 30,
+    },
+    {
+      id: 'd1f74a3a-8b5e-4fa9-904f-7e0a14e9b333',
+      title: 'Language Exchange Meetup',
+      date: '2024-07-03',
+      startTime: '19:00',
+      endTime: '21:00',
+      description: 'Practice languages with native speakers',
+      location: 'Community Center',
+      category: 'Social',
+      repeat: { type: 'weekly', interval: 1, endDate: '2025-02-01' },
+      notificationTime: 20,
+    },
+    {
+      id: 'f5c1b8d4-6a4f-4a11-8234-2f3a1d5c9f98',
+      title: 'Yoga Class',
+      date: '2024-07-24',
+      startTime: '06:00',
+      endTime: '07:00',
+      description: 'Morning Vinyasa yoga for flexibility',
+      location: 'Green Hills Yoga Studio',
+      category: 'Health',
+      repeat: { type: 'daily', interval: 1, endDate: '2024-12-01' },
+      notificationTime: 15,
+    },
+    {
+      id: '9b7c8d5e-1f0e-4d8a-bf23-3e9a1c4e7a45',
+      title: 'Book Club Meeting',
+      date: '2024-11-25',
+      startTime: '18:00',
+      endTime: '19:30',
+      description: 'Discuss the monthly book selection',
+      location: 'Local Library',
+      category: 'Literature',
+      repeat: { type: 'monthly', interval: 1 },
+      notificationTime: 60,
+    },
+    {
+      id: 'c9b3a6f2-2e4a-4c9f-8d32-4d8f1b3e6f78',
+      title: 'Gardening Workshop',
+      date: '2024-09-29',
+      startTime: '11:25',
+      endTime: '14:25',
+      description: 'Learn the basics of sustainable gardening',
+      location: 'Botanical Gardens',
+      category: 'Education',
+      repeat: { type: 'none', interval: 0 },
+      notificationTime: 90, // 1시간 30분 전에 알림
+    },
+    {
+      id: '9b7c8d5e-1f0e-4d8a-bf23-3e9a1c4e7a45',
+      title: '헿',
+      date: '2024-10-01',
+      startTime: '18:00',
+      endTime: '19:25',
+      description: '디스크립션',
+      location: '디스트릭트9',
+      category: '외계인침공영화',
+      repeat: { type: 'monthly', interval: 1 },
+      notificationTime: 50,
+    },
+  ];
+  it("검색어 '이벤트 2'에 맞는 이벤트만 반환한다", () => {
+    const filteredEvents = getFilteredEvents(events, '이벤트 2', new Date(), 'month');
+    expect(filteredEvents).toEqual([
+      {
+        id: 'a7f8d5e0-3f4b-4b8a-9e20-1f46a8c5e123',
+        title: '이벤트 2',
+        date: '2024-11-15',
+        startTime: '14:00',
+        endTime: '17:00',
+        description: 'Learn to cook Italian dishes',
+        location: 'Culinary Arts Studio',
+        category: 'Education',
+        repeat: { type: 'none', interval: 0 },
+        notificationTime: 45,
+      },
+    ]);
+  });
 
-  it('주간 뷰에서 2024-07-01 주의 이벤트만 반환한다', () => {});
+  it('주간 뷰에서 2024-07-01 주의 이벤트만 반환한다', () => {
+    const filteredEvents = getFilteredEvents(events, '', new Date('2024-07-01'), 'week');
+    expect(filteredEvents).toEqual([
+      {
+        id: '5e3d9b2c-17c2-4c8e-8c2b-0f0c0d1f9e56',
+        title: 'Photography Walk',
+        date: '2024-07-02',
+        startTime: '08:00',
+        endTime: '10:30',
+        description: 'Explore urban landscapes through photography',
+        location: 'Central Park',
+        category: 'Hobby',
+        repeat: { type: 'monthly', interval: 1, endDate: '2025-06-18' },
+        notificationTime: 30,
+      },
+      {
+        id: 'd1f74a3a-8b5e-4fa9-904f-7e0a14e9b333',
+        title: 'Language Exchange Meetup',
+        date: '2024-07-03',
+        startTime: '19:00',
+        endTime: '21:00',
+        description: 'Practice languages with native speakers',
+        location: 'Community Center',
+        category: 'Social',
+        repeat: { type: 'weekly', interval: 1, endDate: '2025-02-01' },
+        notificationTime: 20,
+      },
+    ]);
+  });
 
-  it('월간 뷰에서 2024년 7월의 모든 이벤트를 반환한다', () => {});
+  it('월간 뷰에서 2024년 7월의 모든 이벤트를 반환한다', () => {
+    const filteredEvents = getFilteredEvents(events, '', new Date('2024-07-01'), 'month');
+    expect(filteredEvents).toEqual([
+      {
+        id: '5e3d9b2c-17c2-4c8e-8c2b-0f0c0d1f9e56',
+        title: 'Photography Walk',
+        date: '2024-07-02',
+        startTime: '08:00',
+        endTime: '10:30',
+        description: 'Explore urban landscapes through photography',
+        location: 'Central Park',
+        category: 'Hobby',
+        repeat: { type: 'monthly', interval: 1, endDate: '2025-06-18' },
+        notificationTime: 30,
+      },
+      {
+        id: 'd1f74a3a-8b5e-4fa9-904f-7e0a14e9b333',
+        title: 'Language Exchange Meetup',
+        date: '2024-07-03',
+        startTime: '19:00',
+        endTime: '21:00',
+        description: 'Practice languages with native speakers',
+        location: 'Community Center',
+        category: 'Social',
+        repeat: { type: 'weekly', interval: 1, endDate: '2025-02-01' },
+        notificationTime: 20,
+      },
+      {
+        id: 'f5c1b8d4-6a4f-4a11-8234-2f3a1d5c9f98',
+        title: 'Yoga Class',
+        date: '2024-07-24',
+        startTime: '06:00',
+        endTime: '07:00',
+        description: 'Morning Vinyasa yoga for flexibility',
+        location: 'Green Hills Yoga Studio',
+        category: 'Health',
+        repeat: { type: 'daily', interval: 1, endDate: '2024-12-01' },
+        notificationTime: 15,
+      },
+    ]);
+  });
 
-  it("검색어 '이벤트'와 주간 뷰 필터링을 동시에 적용한다", () => {});
+  it("검색어 '이벤트'와 주간 뷰 필터링을 동시에 적용한다", () => {
+    const filteredEvents = getFilteredEvents(events, '이벤트', new Date('2024-11-15'), 'month');
+    expect(filteredEvents).toEqual([
+      {
+        id: 'a7f8d5e0-3f4b-4b8a-9e20-1f46a8c5e123',
+        title: '이벤트 2',
+        date: '2024-11-15',
+        startTime: '14:00',
+        endTime: '17:00',
+        description: 'Learn to cook Italian dishes',
+        location: 'Culinary Arts Studio',
+        category: 'Education',
+        repeat: { type: 'none', interval: 0 },
+        notificationTime: 45,
+      },
+    ]);
+  });
 
-  it('검색어가 없을 때 모든 이벤트를 반환한다', () => {});
+  it('검색어가 없을 때 해당하는 필터(주/월)의 이벤트를 반환한다', () => {
+    const filteredEvents = getFilteredEvents(events, '', new Date(), 'month');
+    expect(filteredEvents).toEqual([
+      {
+        id: 'a7f8d5e0-3f4b-4b8a-9e20-1f46a8c5e123',
+        title: '이벤트 2',
+        date: '2024-11-15',
+        startTime: '14:00',
+        endTime: '17:00',
+        description: 'Learn to cook Italian dishes',
+        location: 'Culinary Arts Studio',
+        category: 'Education',
+        repeat: { type: 'none', interval: 0 },
+        notificationTime: 45,
+      },
+      {
+        id: '9b7c8d5e-1f0e-4d8a-bf23-3e9a1c4e7a45',
+        title: 'Book Club Meeting',
+        date: '2024-11-25',
+        startTime: '18:00',
+        endTime: '19:30',
+        description: 'Discuss the monthly book selection',
+        location: 'Local Library',
+        category: 'Literature',
+        repeat: { type: 'monthly', interval: 1 },
+        notificationTime: 60,
+      },
+    ]);
+  });
 
-  it('검색어가 대소문자를 구분하지 않고 작동한다', () => {});
+  it('검색어가 대소문자를 구분하지 않고 작동한다', () => {
+    const filteredEvents1 = getFilteredEvents(
+      events,
+      'bOoK CLuB MEetIng',
+      new Date('2024-11-25'),
+      'week'
+    );
+    expect(filteredEvents1).toEqual([
+      {
+        id: '9b7c8d5e-1f0e-4d8a-bf23-3e9a1c4e7a45',
+        title: 'Book Club Meeting',
+        date: '2024-11-25',
+        startTime: '18:00',
+        endTime: '19:30',
+        description: 'Discuss the monthly book selection',
+        location: 'Local Library',
+        category: 'Literature',
+        repeat: { type: 'monthly', interval: 1 },
+        notificationTime: 60,
+      },
+    ]);
 
-  it('월의 경계에 있는 이벤트를 올바르게 필터링한다', () => {});
+    const filteredEvents2 = getFilteredEvents(
+      events,
+      'book club MEETING',
+      new Date('2024-11-25'),
+      'week'
+    );
+    expect(filteredEvents2).toEqual([
+      {
+        id: '9b7c8d5e-1f0e-4d8a-bf23-3e9a1c4e7a45',
+        title: 'Book Club Meeting',
+        date: '2024-11-25',
+        startTime: '18:00',
+        endTime: '19:30',
+        description: 'Discuss the monthly book selection',
+        location: 'Local Library',
+        category: 'Literature',
+        repeat: { type: 'monthly', interval: 1 },
+        notificationTime: 60,
+      },
+    ]);
+  });
 
-  it('빈 이벤트 리스트에 대해 빈 배열을 반환한다', () => {});
+  it('월의 경계에 있는 이벤트를 올바르게 필터링한다', () => {
+    const filteredEvents1 = getFilteredEvents(events, '', new Date('2024-09-30'), 'month');
+    expect(filteredEvents1).toEqual([
+      {
+        id: 'c9b3a6f2-2e4a-4c9f-8d32-4d8f1b3e6f78',
+        title: 'Gardening Workshop',
+        date: '2024-09-29',
+        startTime: '11:25',
+        endTime: '14:25',
+        description: 'Learn the basics of sustainable gardening',
+        location: 'Botanical Gardens',
+        category: 'Education',
+        repeat: { type: 'none', interval: 0 },
+        notificationTime: 90, // 1시간 30분 전에 알림
+      },
+    ]);
+
+    const filteredEvents2 = getFilteredEvents(events, '', new Date('2024-10-01'), 'month');
+    expect(filteredEvents2).toEqual([
+      {
+        id: '9b7c8d5e-1f0e-4d8a-bf23-3e9a1c4e7a45',
+        title: '헿',
+        date: '2024-10-01',
+        startTime: '18:00',
+        endTime: '19:25',
+        description: '디스크립션',
+        location: '디스트릭트9',
+        category: '외계인침공영화',
+        repeat: { type: 'monthly', interval: 1 },
+        notificationTime: 50,
+      },
+    ]);
+  });
+
+  it('빈 이벤트 리스트에 대해 빈 배열을 반환한다', () => {
+    const filteredEvents = getFilteredEvents([], '', new Date('2024-09-30'), 'month');
+    expect(filteredEvents).toEqual([]);
+  });
 });

--- a/src/__tests__/unit/easy.fetchHolidays.spec.ts
+++ b/src/__tests__/unit/easy.fetchHolidays.spec.ts
@@ -1,9 +1,22 @@
 import { fetchHolidays } from '../../apis/fetchHolidays';
 
 describe('fetchHolidays', () => {
-  it('주어진 월의 공휴일만 반환한다', () => {});
+  it('주어진 월의 공휴일만 반환한다', () => {
+    const holidaysInMonth = fetchHolidays(new Date('2024-01'));
+    expect(holidaysInMonth).toEqual({ '2024-01-01': '신정' });
+  });
 
-  it('공휴일이 없는 월에 대해 빈 객체를 반환한다', () => {});
+  it('공휴일이 없는 월에 대해 빈 객체를 반환한다', () => {
+    const holidaysInMonth = fetchHolidays(new Date('2024-11'));
+    expect(holidaysInMonth).toEqual({});
+  });
 
-  it('여러 공휴일이 있는 월에 대해 모든 공휴일을 반환한다', () => {});
+  it('여러 공휴일이 있는 월에 대해 모든 공휴일을 반환한다', () => {
+    const holidaysInMonth = fetchHolidays(new Date('2024-02'));
+    expect(holidaysInMonth).toEqual({
+      '2024-02-09': '설날',
+      '2024-02-10': '설날',
+      '2024-02-11': '설날',
+    });
+  });
 });

--- a/src/__tests__/unit/easy.notificationUtils.spec.ts
+++ b/src/__tests__/unit/easy.notificationUtils.spec.ts
@@ -2,15 +2,166 @@ import { Event } from '../../types';
 import { createNotificationMessage, getUpcomingEvents } from '../../utils/notificationUtils';
 
 describe('getUpcomingEvents', () => {
-  it('알림 시간이 정확히 도래한 이벤트를 반환한다', () => {});
+  const events: Event[] = [
+    {
+      id: 'a7f8d5e0-3f4b-4b8a-9e20-1f46a8c5e123',
+      title: 'Cooking Workshop',
+      date: '2024-11-15',
+      startTime: '14:00',
+      endTime: '17:00',
+      description: 'Learn to cook Italian dishes',
+      location: 'Culinary Arts Studio',
+      category: 'Education',
+      repeat: { type: 'none', interval: 0 },
+      notificationTime: 45,
+    },
+    {
+      id: '5e3d9b2c-17c2-4c8e-8c2b-0f0c0d1f9e56',
+      title: 'Photography Walk',
+      date: '2024-11-15',
+      startTime: '14:10',
+      endTime: '15:30',
+      description: 'Explore urban landscapes through photography',
+      location: 'Central Park',
+      category: 'Hobby',
+      repeat: { type: 'monthly', interval: 1, endDate: '2025-06-18' },
+      notificationTime: 30,
+    },
+    {
+      id: 'd1f74a3a-8b5e-4fa9-904f-7e0a14e9b333',
+      title: 'Language Exchange Meetup',
+      date: '2024-11-20',
+      startTime: '19:00',
+      endTime: '21:00',
+      description: 'Practice languages with native speakers',
+      location: 'Community Center',
+      category: 'Social',
+      repeat: { type: 'weekly', interval: 1, endDate: '2025-02-01' },
+      notificationTime: 20,
+    },
+    {
+      id: 'f5c1b8d4-6a4f-4a11-8234-2f3a1d5c9f98',
+      title: 'Yoga Class',
+      date: '2024-11-22',
+      startTime: '06:00',
+      endTime: '07:00',
+      description: 'Morning Vinyasa yoga for flexibility',
+      location: 'Green Hills Yoga Studio',
+      category: 'Health',
+      repeat: { type: 'daily', interval: 1, endDate: '2024-12-01' },
+      notificationTime: 15,
+    },
+    {
+      id: '9b7c8d5e-1f0e-4d8a-bf23-3e9a1c4e7a45',
+      title: 'Book Club Meeting',
+      date: '2024-11-25',
+      startTime: '18:00',
+      endTime: '19:30',
+      description: 'Discuss the monthly book selection',
+      location: 'Local Library',
+      category: 'Literature',
+      repeat: { type: 'monthly', interval: 1 },
+      notificationTime: 60,
+    },
+  ];
+  it('알림 시간이 정확히 도래한 이벤트를 반환한다', () => {
+    const upcommingEvents = getUpcomingEvents(events, new Date('2024-11-15T13:59'), []);
+    expect(upcommingEvents).toEqual([
+      {
+        id: 'a7f8d5e0-3f4b-4b8a-9e20-1f46a8c5e123',
+        title: 'Cooking Workshop',
+        date: '2024-11-15',
+        startTime: '14:00',
+        endTime: '17:00',
+        description: 'Learn to cook Italian dishes',
+        location: 'Culinary Arts Studio',
+        category: 'Education',
+        repeat: { type: 'none', interval: 0 },
+        notificationTime: 45,
+      },
+      {
+        id: '5e3d9b2c-17c2-4c8e-8c2b-0f0c0d1f9e56',
+        title: 'Photography Walk',
+        date: '2024-11-15',
+        startTime: '14:10',
+        endTime: '15:30',
+        description: 'Explore urban landscapes through photography',
+        location: 'Central Park',
+        category: 'Hobby',
+        repeat: { type: 'monthly', interval: 1, endDate: '2025-06-18' },
+        notificationTime: 30,
+      },
+    ]);
+  });
 
-  it('이미 알림이 간 이벤트는 제외한다', () => {});
+  it('이미 알림이 간 이벤트는 제외한다', () => {
+    const upcommingEvents = getUpcomingEvents(events, new Date('2024-11-15T13:59'), [
+      'a7f8d5e0-3f4b-4b8a-9e20-1f46a8c5e123',
+    ]);
+    expect(upcommingEvents).toEqual([
+      {
+        id: '5e3d9b2c-17c2-4c8e-8c2b-0f0c0d1f9e56',
+        title: 'Photography Walk',
+        date: '2024-11-15',
+        startTime: '14:10',
+        endTime: '15:30',
+        description: 'Explore urban landscapes through photography',
+        location: 'Central Park',
+        category: 'Hobby',
+        repeat: { type: 'monthly', interval: 1, endDate: '2025-06-18' },
+        notificationTime: 30,
+      },
+    ]);
+  });
 
-  it('알림 시간이 아직 도래하지 않은 이벤트는 반환하지 않는다', () => {});
+  it('알림 시간이 아직 도래하지 않은 이벤트는 반환하지 않는다', () => {
+    const upcommingEvents = getUpcomingEvents(events, new Date('2024-11-22T05:00'), []);
+    expect(upcommingEvents).not.toEqual({
+      id: 'f5c1b8d4-6a4f-4a11-8234-2f3a1d5c9f98',
+      title: 'Yoga Class',
+      date: '2024-11-22',
+      startTime: '06:00',
+      endTime: '07:00',
+      description: 'Morning Vinyasa yoga for flexibility',
+      location: 'Green Hills Yoga Studio',
+      category: 'Health',
+      repeat: { type: 'daily', interval: 1, endDate: '2024-12-01' },
+      notificationTime: 15,
+    });
+  });
 
-  it('알림 시간이 지난 이벤트는 반환하지 않는다', () => {});
+  it('알림 시간이 지난 이벤트는 반환하지 않는다', () => {
+    const upcommingEvents = getUpcomingEvents(events, new Date('2024-11-22T05:00'), []);
+    expect(upcommingEvents).not.toEqual({
+      id: 'a7f8d5e0-3f4b-4b8a-9e20-1f46a8c5e123',
+      title: 'Cooking Workshop',
+      date: '2024-11-15',
+      startTime: '14:00',
+      endTime: '17:00',
+      description: 'Learn to cook Italian dishes',
+      location: 'Culinary Arts Studio',
+      category: 'Education',
+      repeat: { type: 'none', interval: 0 },
+      notificationTime: 45,
+    });
+  });
 });
 
 describe('createNotificationMessage', () => {
-  it('올바른 알림 메시지를 생성해야 한다', () => {});
+  it('올바른 알림 메시지를 생성해야 한다', () => {
+    const notificationMessage = createNotificationMessage({
+      id: 'a7f8d5e0-3f4b-4b8a-9e20-1f46a8c5e123',
+      title: 'Cooking Workshop',
+      date: '2024-11-15',
+      startTime: '14:00',
+      endTime: '17:00',
+      description: 'Learn to cook Italian dishes',
+      location: 'Culinary Arts Studio',
+      category: 'Education',
+      repeat: { type: 'none', interval: 0 },
+      notificationTime: 45,
+    });
+
+    expect(notificationMessage).toBe('45분 후 Cooking Workshop 일정이 시작됩니다.');
+  });
 });

--- a/src/__tests__/unit/easy.timeValidation.spec.ts
+++ b/src/__tests__/unit/easy.timeValidation.spec.ts
@@ -1,15 +1,39 @@
 import { getTimeErrorMessage } from '../../utils/timeValidation';
 
 describe('getTimeErrorMessage >', () => {
-  it('시작 시간이 종료 시간보다 늦을 때 에러 메시지를 반환한다', () => {});
+  it('시작 시간이 종료 시간보다 늦을 때 에러 메시지를 반환한다', () => {
+    const timeErrorMessage = getTimeErrorMessage('08:31', '06:50');
+    expect(timeErrorMessage).toEqual({
+      startTimeError: '시작 시간은 종료 시간보다 빨라야 합니다.',
+      endTimeError: '종료 시간은 시작 시간보다 늦어야 합니다.',
+    });
+  });
 
-  it('시작 시간과 종료 시간이 같을 때 에러 메시지를 반환한다', () => {});
+  it('시작 시간과 종료 시간이 같을 때 에러 메시지를 반환한다', () => {
+    const timeErrorMessage = getTimeErrorMessage('08:31', '08:31');
+    expect(timeErrorMessage).toEqual({
+      startTimeError: '시작 시간은 종료 시간보다 빨라야 합니다.',
+      endTimeError: '종료 시간은 시작 시간보다 늦어야 합니다.',
+    });
+  });
 
-  it('시작 시간이 종료 시간보다 빠를 때 null을 반환한다', () => {});
+  it('시작 시간이 종료 시간보다 빠를 때 null을 반환한다', () => {
+    const timeErrorMessage = getTimeErrorMessage('04:20', '08:31');
+    expect(timeErrorMessage).toEqual({ startTimeError: null, endTimeError: null });
+  });
 
-  it('시작 시간이 비어있을 때 null을 반환한다', () => {});
+  it('시작 시간이 비어있을 때 null을 반환한다', () => {
+    const timeErrorMessage = getTimeErrorMessage('', '08:31');
+    expect(timeErrorMessage).toEqual({ startTimeError: null, endTimeError: null });
+  });
 
-  it('종료 시간이 비어있을 때 null을 반환한다', () => {});
+  it('종료 시간이 비어있을 때 null을 반환한다', () => {
+    const timeErrorMessage = getTimeErrorMessage('04:20', '');
+    expect(timeErrorMessage).toEqual({ startTimeError: null, endTimeError: null });
+  });
 
-  it('시작 시간과 종료 시간이 모두 비어있을 때 null을 반환한다', () => {});
+  it('시작 시간과 종료 시간이 모두 비어있을 때 null을 반환한다', () => {
+    const timeErrorMessage = getTimeErrorMessage('', '');
+    expect(timeErrorMessage).toEqual({ startTimeError: null, endTimeError: null });
+  });
 });

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -1,0 +1,67 @@
+import { BellIcon, DeleteIcon, EditIcon } from '@chakra-ui/icons';
+import { Box, HStack, IconButton, Text, VStack } from '@chakra-ui/react';
+
+import { Event } from '../types.tsx';
+
+interface EventCardProps {
+  event: Event;
+  notifiedEvents: string[];
+  notificationOptions: {
+    value: number;
+    label: string;
+  }[];
+}
+
+export const EventCard = ({ event, notifiedEvents, notificationOptions }: EventCardProps) => {
+  return (
+    <Box borderWidth={1} borderRadius="lg" p={3} width="100%">
+      <HStack justifyContent="space-between">
+        <VStack align="start">
+          <HStack>
+            {notifiedEvents.includes(event.id) && <BellIcon color="red.500" />}
+            <Text
+              fontWeight={notifiedEvents.includes(event.id) ? 'bold' : 'normal'}
+              color={notifiedEvents.includes(event.id) ? 'red.500' : 'inherit'}
+            >
+              {event.title}
+            </Text>
+          </HStack>
+          <Text>{event.date}</Text>
+          <Text>
+            {event.startTime} - {event.endTime}
+          </Text>
+          <Text>{event.description}</Text>
+          <Text>{event.location}</Text>
+          <Text>카테고리: {event.category}</Text>
+          {event.repeat.type !== 'none' && (
+            <Text>
+              반복: {event.repeat.interval}
+              {event.repeat.type === 'daily' && '일'}
+              {event.repeat.type === 'weekly' && '주'}
+              {event.repeat.type === 'monthly' && '월'}
+              {event.repeat.type === 'yearly' && '년'}
+              마다
+              {event.repeat.endDate && ` (종료: ${event.repeat.endDate})`}
+            </Text>
+          )}
+          <Text>
+            알림:{' '}
+            {notificationOptions.find((option) => option.value === event.notificationTime)?.label}
+          </Text>
+        </VStack>
+        <HStack>
+          {/* <IconButton
+            aria-label="Edit event"
+            icon={<EditIcon />}
+            onClick={() => editEvent(event)}
+          />
+          <IconButton
+            aria-label="Delete event"
+            icon={<DeleteIcon />}
+            onClick={() => deleteEvent(event.id)}
+          /> */}
+        </HStack>
+      </HStack>
+    </Box>
+  );
+};

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 import { BellIcon, DeleteIcon, EditIcon } from '@chakra-ui/icons';
 import { Box, HStack, IconButton, Text, VStack } from '@chakra-ui/react';
 
@@ -10,9 +11,17 @@ interface EventCardProps {
     value: number;
     label: string;
   }[];
+  editEvent: (event: Event) => void;
+  deleteEvent: (id: string) => Promise<void>;
 }
 
-export const EventCard = ({ event, notifiedEvents, notificationOptions }: EventCardProps) => {
+export const EventCard = ({
+  event,
+  notifiedEvents,
+  notificationOptions,
+  editEvent,
+  deleteEvent,
+}: EventCardProps) => {
   return (
     <Box borderWidth={1} borderRadius="lg" p={3} width="100%">
       <HStack justifyContent="space-between">
@@ -50,7 +59,7 @@ export const EventCard = ({ event, notifiedEvents, notificationOptions }: EventC
           </Text>
         </VStack>
         <HStack>
-          {/* <IconButton
+          <IconButton
             aria-label="Edit event"
             icon={<EditIcon />}
             onClick={() => editEvent(event)}
@@ -59,7 +68,7 @@ export const EventCard = ({ event, notifiedEvents, notificationOptions }: EventC
             aria-label="Delete event"
             icon={<DeleteIcon />}
             onClick={() => deleteEvent(event.id)}
-          /> */}
+          />
         </HStack>
       </HStack>
     </Box>

--- a/src/components/EventHandleForm.tsx
+++ b/src/components/EventHandleForm.tsx
@@ -1,0 +1,242 @@
+import {
+  Button,
+  Checkbox,
+  FormControl,
+  FormLabel,
+  Heading,
+  HStack,
+  Input,
+  Select,
+  Tooltip,
+  useToast,
+  VStack,
+} from '@chakra-ui/react';
+import { useRef, useState } from 'react';
+
+import { useEventForm } from '../hooks/useEventForm';
+import { EventForm, RepeatType } from '../types';
+import { findOverlappingEvents } from '../utils/eventOverlap';
+import { getTimeErrorMessage } from '../utils/timeValidation';
+
+const categories = ['업무', '개인', '가족', '기타'];
+
+const notificationOptions = [
+  { value: 1, label: '1분 전' },
+  { value: 10, label: '10분 전' },
+  { value: 60, label: '1시간 전' },
+  { value: 120, label: '2시간 전' },
+  { value: 1440, label: '1일 전' },
+];
+
+export const EventHandleForm = () => {
+  const toast = useToast();
+  const {
+    title,
+    setTitle,
+    date,
+    setDate,
+    startTime,
+    endTime,
+    description,
+    setDescription,
+    location,
+    setLocation,
+    category,
+    setCategory,
+    isRepeating,
+    setIsRepeating,
+    repeatType,
+    setRepeatType,
+    repeatInterval,
+    setRepeatInterval,
+    repeatEndDate,
+    setRepeatEndDate,
+    notificationTime,
+    setNotificationTime,
+    startTimeError,
+    endTimeError,
+    editingEvent,
+    setEditingEvent,
+    handleStartTimeChange,
+    handleEndTimeChange,
+    resetForm,
+    editEvent,
+  } = useEventForm();
+
+  const [overlappingEvents, setOverlappingEvents] = useState<Event[]>([]);
+  const [isOverlapDialogOpen, setIsOverlapDialogOpen] = useState(false);
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  const addOrUpdateEvent = async () => {
+    if (!title || !date || !startTime || !endTime) {
+      toast({
+        title: '필수 정보를 모두 입력해주세요.',
+        status: 'error',
+        duration: 3000,
+        isClosable: true,
+      });
+      return;
+    }
+
+    if (startTimeError || endTimeError) {
+      toast({
+        title: '시간 설정을 확인해주세요.',
+        status: 'error',
+        duration: 3000,
+        isClosable: true,
+      });
+      return;
+    }
+
+    const eventData: Event | EventForm = {
+      id: editingEvent ? editingEvent.id : undefined,
+      title,
+      date,
+      startTime,
+      endTime,
+      description,
+      location,
+      category,
+      repeat: {
+        type: isRepeating ? repeatType : 'none',
+        interval: repeatInterval,
+        endDate: repeatEndDate || undefined,
+      },
+      notificationTime,
+    };
+
+    // const overlapping = findOverlappingEvents(eventData, events);
+    // if (overlapping.length > 0) {
+    //   setOverlappingEvents(overlapping);
+    //   setIsOverlapDialogOpen(true);
+    // } else {
+    //   await saveEvent(eventData);
+    //   resetForm();
+    // }
+  };
+  return (
+    <VStack w="400px" spacing={5} align="stretch">
+      <Heading>{editingEvent ? '일정 수정' : '일정 추가'}</Heading>
+
+      <FormControl>
+        <FormLabel>제목</FormLabel>
+        <Input value={title} onChange={(e) => setTitle(e.target.value)} />
+      </FormControl>
+
+      <FormControl>
+        <FormLabel>날짜</FormLabel>
+        <Input type="date" value={date} onChange={(e) => setDate(e.target.value)} />
+      </FormControl>
+
+      <HStack width="100%">
+        <FormControl>
+          <FormLabel>시작 시간</FormLabel>
+          <Tooltip label={startTimeError} isOpen={!!startTimeError} placement="top">
+            <Input
+              type="time"
+              value={startTime}
+              onChange={handleStartTimeChange}
+              onBlur={() => getTimeErrorMessage(startTime, endTime)}
+              isInvalid={!!startTimeError}
+            />
+          </Tooltip>
+        </FormControl>
+        <FormControl>
+          <FormLabel>종료 시간</FormLabel>
+          <Tooltip label={endTimeError} isOpen={!!endTimeError} placement="top">
+            <Input
+              type="time"
+              value={endTime}
+              onChange={handleEndTimeChange}
+              onBlur={() => getTimeErrorMessage(startTime, endTime)}
+              isInvalid={!!endTimeError}
+            />
+          </Tooltip>
+        </FormControl>
+      </HStack>
+
+      <FormControl>
+        <FormLabel>설명</FormLabel>
+        <Input value={description} onChange={(e) => setDescription(e.target.value)} />
+      </FormControl>
+
+      <FormControl>
+        <FormLabel>위치</FormLabel>
+        <Input value={location} onChange={(e) => setLocation(e.target.value)} />
+      </FormControl>
+
+      <FormControl>
+        <FormLabel>카테고리</FormLabel>
+        <Select value={category} onChange={(e) => setCategory(e.target.value)}>
+          <option value="">카테고리 선택</option>
+          {categories.map((cat) => (
+            <option key={cat} value={cat}>
+              {cat}
+            </option>
+          ))}
+        </Select>
+      </FormControl>
+
+      <FormControl>
+        <FormLabel>반복 설정</FormLabel>
+        <Checkbox isChecked={isRepeating} onChange={(e) => setIsRepeating(e.target.checked)}>
+          반복 일정
+        </Checkbox>
+      </FormControl>
+
+      <FormControl>
+        <FormLabel>알림 설정</FormLabel>
+        <Select
+          value={notificationTime}
+          onChange={(e) => setNotificationTime(Number(e.target.value))}
+        >
+          {notificationOptions.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </Select>
+      </FormControl>
+
+      {isRepeating && (
+        <VStack width="100%">
+          <FormControl>
+            <FormLabel>반복 유형</FormLabel>
+            <Select
+              value={repeatType}
+              onChange={(e) => setRepeatType(e.target.value as RepeatType)}
+            >
+              <option value="daily">매일</option>
+              <option value="weekly">매주</option>
+              <option value="monthly">매월</option>
+              <option value="yearly">매년</option>
+            </Select>
+          </FormControl>
+          <HStack width="100%">
+            <FormControl>
+              <FormLabel>반복 간격</FormLabel>
+              <Input
+                type="number"
+                value={repeatInterval}
+                onChange={(e) => setRepeatInterval(Number(e.target.value))}
+                min={1}
+              />
+            </FormControl>
+            <FormControl>
+              <FormLabel>반복 종료일</FormLabel>
+              <Input
+                type="date"
+                value={repeatEndDate}
+                onChange={(e) => setRepeatEndDate(e.target.value)}
+              />
+            </FormControl>
+          </HStack>
+        </VStack>
+      )}
+
+      <Button data-testid="event-submit-button" onClick={addOrUpdateEvent} colorScheme="blue">
+        {editingEvent ? '일정 수정' : '일정 추가'}
+      </Button>
+    </VStack>
+  );
+};

--- a/src/components/EventHandleNavigate.tsx
+++ b/src/components/EventHandleNavigate.tsx
@@ -1,0 +1,31 @@
+import { ChevronLeftIcon, ChevronRightIcon } from '@chakra-ui/icons';
+import { HStack, IconButton, Select } from '@chakra-ui/react';
+import React from 'react';
+
+interface EventHandleNavigateProps {
+  view: 'week' | 'month';
+  setView: React.Dispatch<React.SetStateAction<'week' | 'month'>>;
+  // eslint-disable-next-line no-unused-vars
+  navigate: (direction: 'prev' | 'next') => void;
+}
+
+export const EventHandleNavigate = ({ view, setView, navigate }: EventHandleNavigateProps) => {
+  return (
+    <HStack mx="auto" justifyContent="space-between">
+      <IconButton
+        aria-label="Previous"
+        icon={<ChevronLeftIcon />}
+        onClick={() => navigate('prev')}
+      />
+      <Select
+        aria-label="view"
+        value={view}
+        onChange={(e) => setView(e.target.value as 'week' | 'month')}
+      >
+        <option value="week">Week</option>
+        <option value="month">Month</option>
+      </Select>
+      <IconButton aria-label="Next" icon={<ChevronRightIcon />} onClick={() => navigate('next')} />
+    </HStack>
+  );
+};

--- a/src/components/MonthView.tsx
+++ b/src/components/MonthView.tsx
@@ -1,0 +1,104 @@
+import { BellIcon } from '@chakra-ui/icons';
+import {
+  Box,
+  Heading,
+  HStack,
+  Table,
+  Tbody,
+  Td,
+  Text,
+  Th,
+  Thead,
+  Tr,
+  VStack,
+} from '@chakra-ui/react';
+
+import { Event } from '../types';
+import { formatDate, formatMonth, getEventsForDay, getWeeksAtMonth } from '../utils/dateUtils';
+
+const weekDays = ['일', '월', '화', '수', '목', '금', '토'];
+
+interface MonthViewProps {
+  currentDate: Date;
+  holidays: { [key: string]: string };
+  filteredEvents: Event[];
+  notifiedEvents: string[];
+}
+
+export const MonthView = ({
+  currentDate,
+  holidays,
+  filteredEvents,
+  notifiedEvents,
+}: MonthViewProps) => {
+  const weeks = getWeeksAtMonth(currentDate);
+
+  return (
+    <VStack data-testid="month-view" align="stretch" w="full" spacing={4}>
+      <Heading size="md">{formatMonth(currentDate)}</Heading>
+      <Table variant="simple" w="full">
+        <Thead>
+          <Tr>
+            {weekDays.map((day) => (
+              <Th key={day} width="14.28%">
+                {day}
+              </Th>
+            ))}
+          </Tr>
+        </Thead>
+        <Tbody>
+          {weeks.map((week, weekIndex) => (
+            <Tr key={weekIndex}>
+              {week.map((day, dayIndex) => {
+                const dateString = day ? formatDate(currentDate, day) : '';
+                const holiday = holidays[dateString];
+
+                return (
+                  <Td
+                    key={dayIndex}
+                    height="100px"
+                    verticalAlign="top"
+                    width="14.28%"
+                    position="relative"
+                  >
+                    {day && (
+                      <>
+                        <Text fontWeight="bold">{day}</Text>
+                        {holiday && (
+                          <Text color="red.500" fontSize="sm">
+                            {holiday}
+                          </Text>
+                        )}
+                        {getEventsForDay(filteredEvents, day).map((event) => {
+                          const isNotified = notifiedEvents.includes(event.id);
+                          return (
+                            <Box
+                              key={event.id}
+                              p={1}
+                              my={1}
+                              bg={isNotified ? 'red.100' : 'gray.100'}
+                              borderRadius="md"
+                              fontWeight={isNotified ? 'bold' : 'normal'}
+                              color={isNotified ? 'red.500' : 'inherit'}
+                            >
+                              <HStack spacing={1}>
+                                {isNotified && <BellIcon />}
+                                <Text fontSize="sm" noOfLines={1}>
+                                  {event.title}
+                                </Text>
+                              </HStack>
+                            </Box>
+                          );
+                        })}
+                      </>
+                    )}
+                  </Td>
+                );
+              })}
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+    </VStack>
+  );
+};

--- a/src/components/NotificationAlert.tsx
+++ b/src/components/NotificationAlert.tsx
@@ -1,0 +1,34 @@
+import { Alert, AlertIcon, AlertTitle, Box, CloseButton } from '@chakra-ui/react';
+import React from 'react';
+
+interface NotificationAlertProps {
+  notification: {
+    id: string;
+    message: string;
+  };
+  setNotifications: React.Dispatch<
+    React.SetStateAction<
+      {
+        id: string;
+        message: string;
+      }[]
+    >
+  >;
+  index: number;
+}
+
+export const NotificationAlert = ({
+  notification,
+  setNotifications,
+  index,
+}: NotificationAlertProps) => {
+  return (
+    <Alert status="info" variant="solid" width="auto">
+      <AlertIcon />
+      <Box flex="1">
+        <AlertTitle fontSize="sm">{notification.message}</AlertTitle>
+      </Box>
+      <CloseButton onClick={() => setNotifications((prev) => prev.filter((_, i) => i !== index))} />
+    </Alert>
+  );
+};

--- a/src/components/OverlappingEventDialog.tsx
+++ b/src/components/OverlappingEventDialog.tsx
@@ -18,6 +18,9 @@ interface OverlappingEventDialogProps {
   overlappingEvents: Event[];
   // eslint-disable-next-line no-unused-vars
   saveEvent: (eventData: Event | EventForm) => Promise<void>;
+  eventForm: EventForm;
+  editingEvent: Event | null;
+  isRepeating: boolean;
 }
 
 export const OverlappingEventDialog = ({
@@ -25,6 +28,9 @@ export const OverlappingEventDialog = ({
   close,
   overlappingEvents,
   saveEvent,
+  eventForm,
+  editingEvent,
+  isRepeating,
 }: OverlappingEventDialogProps) => {
   const cancelRef = useRef<HTMLButtonElement>(null);
 
@@ -54,22 +60,15 @@ export const OverlappingEventDialog = ({
               colorScheme="red"
               onClick={() => {
                 close();
-                // saveEvent({
-                //   id: editingEvent ? editingEvent.id : undefined,
-                //   title,
-                //   date,
-                //   startTime,
-                //   endTime,
-                //   description,
-                //   location,
-                //   category,
-                //   repeat: {
-                //     type: isRepeating ? repeatType : 'none',
-                //     interval: repeatInterval,
-                //     endDate: repeatEndDate || undefined,
-                //   },
-                //   notificationTime,
-                // });
+                saveEvent({
+                  id: editingEvent ? editingEvent.id : undefined,
+                  ...eventForm,
+                  repeat: {
+                    type: isRepeating ? eventForm.repeat.type : 'none',
+                    interval: eventForm.repeat.interval,
+                    endDate: eventForm.repeat.endDate || undefined,
+                  },
+                });
               }}
               ml={3}
             >

--- a/src/components/OverlappingEventDialog.tsx
+++ b/src/components/OverlappingEventDialog.tsx
@@ -1,0 +1,83 @@
+import {
+  AlertDialog,
+  AlertDialogBody,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  Button,
+  Text,
+} from '@chakra-ui/react';
+import { useRef } from 'react';
+
+import { Event, EventForm } from '../types';
+
+interface OverlappingEventDialogProps {
+  isOpen: boolean;
+  close: () => void;
+  overlappingEvents: Event[];
+  // eslint-disable-next-line no-unused-vars
+  saveEvent: (eventData: Event | EventForm) => Promise<void>;
+}
+
+export const OverlappingEventDialog = ({
+  isOpen,
+  close,
+  overlappingEvents,
+  saveEvent,
+}: OverlappingEventDialogProps) => {
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  return (
+    <AlertDialog isOpen={isOpen} leastDestructiveRef={cancelRef} onClose={() => close}>
+      <AlertDialogOverlay>
+        <AlertDialogContent>
+          <AlertDialogHeader fontSize="lg" fontWeight="bold">
+            일정 겹침 경고
+          </AlertDialogHeader>
+
+          <AlertDialogBody>
+            다음 일정과 겹칩니다:
+            {overlappingEvents.map((event) => (
+              <Text key={event.id}>
+                {event.title} ({event.date} {event.startTime}-{event.endTime})
+              </Text>
+            ))}
+            계속 진행하시겠습니까?
+          </AlertDialogBody>
+
+          <AlertDialogFooter>
+            <Button ref={cancelRef} onClick={() => close}>
+              취소
+            </Button>
+            <Button
+              colorScheme="red"
+              onClick={() => {
+                close();
+                // saveEvent({
+                //   id: editingEvent ? editingEvent.id : undefined,
+                //   title,
+                //   date,
+                //   startTime,
+                //   endTime,
+                //   description,
+                //   location,
+                //   category,
+                //   repeat: {
+                //     type: isRepeating ? repeatType : 'none',
+                //     interval: repeatInterval,
+                //     endDate: repeatEndDate || undefined,
+                //   },
+                //   notificationTime,
+                // });
+              }}
+              ml={3}
+            >
+              계속 진행
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialogOverlay>
+    </AlertDialog>
+  );
+};

--- a/src/components/WeekView.tsx
+++ b/src/components/WeekView.tsx
@@ -1,0 +1,78 @@
+import { BellIcon } from '@chakra-ui/icons';
+import {
+  Box,
+  Heading,
+  HStack,
+  Table,
+  Tbody,
+  Td,
+  Text,
+  Th,
+  Thead,
+  Tr,
+  VStack,
+} from '@chakra-ui/react';
+
+import { Event } from '../types';
+import { formatWeek, getWeekDates } from '../utils/dateUtils';
+
+interface WeekViewProps {
+  currentDate: Date;
+  filteredEvents: Event[];
+  notifiedEvents: string[];
+}
+
+const weekDays = ['일', '월', '화', '수', '목', '금', '토'];
+
+export const WeekView = ({ currentDate, filteredEvents, notifiedEvents }: WeekViewProps) => {
+  const weekDates = getWeekDates(currentDate);
+
+  return (
+    <VStack data-testid="week-view" align="stretch" w="full" spacing={4}>
+      <Heading size="md">{formatWeek(currentDate)}</Heading>
+      <Table variant="simple" w="full">
+        <Thead>
+          <Tr>
+            {weekDays.map((day) => (
+              <Th key={day} width="14.28%">
+                {day}
+              </Th>
+            ))}
+          </Tr>
+        </Thead>
+        <Tbody>
+          <Tr>
+            {weekDates.map((date) => (
+              <Td key={date.toISOString()} height="100px" verticalAlign="top" width="14.28%">
+                <Text fontWeight="bold">{date.getDate()}</Text>
+                {filteredEvents
+                  .filter((event) => new Date(event.date).toDateString() === date.toDateString())
+                  .map((event) => {
+                    const isNotified = notifiedEvents.includes(event.id);
+                    return (
+                      <Box
+                        key={event.id}
+                        p={1}
+                        my={1}
+                        bg={isNotified ? 'red.100' : 'gray.100'}
+                        borderRadius="md"
+                        fontWeight={isNotified ? 'bold' : 'normal'}
+                        color={isNotified ? 'red.500' : 'inherit'}
+                      >
+                        <HStack spacing={1}>
+                          {isNotified && <BellIcon />}
+                          <Text fontSize="sm" noOfLines={1}>
+                            {event.title}
+                          </Text>
+                        </HStack>
+                      </Box>
+                    );
+                  })}
+              </Td>
+            ))}
+          </Tr>
+        </Tbody>
+      </Table>
+    </VStack>
+  );
+};

--- a/src/hooks/useEditingEvent.ts
+++ b/src/hooks/useEditingEvent.ts
@@ -1,0 +1,21 @@
+/* eslint-disable no-unused-vars */
+import { Dispatch, SetStateAction, useState } from 'react';
+
+import { Event, EventForm } from '../types';
+
+interface UseEditingEventProps {
+  setEventForm: Dispatch<SetStateAction<EventForm>>;
+  setIsRepeating: Dispatch<SetStateAction<boolean>>;
+}
+
+export const useEditingEvent = ({ setEventForm, setIsRepeating }: UseEditingEventProps) => {
+  const [editingEvent, setEditingEvent] = useState<Event | null>(null);
+
+  const editEvent = (event: Event) => {
+    setEventForm(event);
+    setEditingEvent(event);
+    setIsRepeating(event.repeat.type !== 'none');
+  };
+
+  return { editingEvent, setEditingEvent, editEvent };
+};

--- a/src/hooks/useEventForm.ts
+++ b/src/hooks/useEventForm.ts
@@ -1,106 +1,76 @@
 import { ChangeEvent, useState } from 'react';
 
-import { Event, RepeatType } from '../types';
+import { EventForm, RepeatInfo } from '../types';
 import { getTimeErrorMessage } from '../utils/timeValidation';
 
 type TimeErrorRecord = Record<'startTimeError' | 'endTimeError', string | null>;
 
-export const useEventForm = (initialEvent?: Event) => {
-  const [title, setTitle] = useState(initialEvent?.title || '');
-  const [date, setDate] = useState(initialEvent?.date || '');
-  const [startTime, setStartTime] = useState(initialEvent?.startTime || '');
-  const [endTime, setEndTime] = useState(initialEvent?.endTime || '');
-  const [description, setDescription] = useState(initialEvent?.description || '');
-  const [location, setLocation] = useState(initialEvent?.location || '');
-  const [category, setCategory] = useState(initialEvent?.category || '');
+const initialEventValue: EventForm = {
+  title: '',
+  date: '',
+  startTime: '',
+  endTime: '',
+  description: '',
+  location: '',
+  category: '',
+  repeat: {
+    type: 'none',
+    interval: 1,
+    endDate: '',
+  },
+  notificationTime: 10,
+};
+
+export const useEventForm = (initialEvent?: EventForm) => {
+  const [eventForm, setEventForm] = useState<EventForm>(initialEvent || initialEventValue);
+
   const [isRepeating, setIsRepeating] = useState(initialEvent?.repeat.type !== 'none');
-  const [repeatType, setRepeatType] = useState<RepeatType>(initialEvent?.repeat.type || 'none');
-  const [repeatInterval, setRepeatInterval] = useState(initialEvent?.repeat.interval || 1);
-  const [repeatEndDate, setRepeatEndDate] = useState(initialEvent?.repeat.endDate || '');
-  const [notificationTime, setNotificationTime] = useState(initialEvent?.notificationTime || 10);
-
-  const [editingEvent, setEditingEvent] = useState<Event | null>(null);
-
   const [{ startTimeError, endTimeError }, setTimeError] = useState<TimeErrorRecord>({
     startTimeError: null,
     endTimeError: null,
   });
 
+  const eventFormChange = <T, K extends keyof T>(prev: T, key: K, value: T[K]) => {
+    return { ...prev, [key]: value };
+  };
+
+  const handleChangeFormContent = <K extends keyof EventForm>(key: K, value: EventForm[K]) => {
+    setEventForm((prev) => eventFormChange(prev, key, value));
+  };
+
+  const handleChangeFormRepeat = <K extends keyof RepeatInfo>(key: K, value: RepeatInfo[K]) => {
+    setEventForm((prev) => ({ ...prev, repeat: eventFormChange(prev.repeat, key, value) }));
+  };
+
   const handleStartTimeChange = (e: ChangeEvent<HTMLInputElement>) => {
     const newStartTime = e.target.value;
-    setStartTime(newStartTime);
-    setTimeError(getTimeErrorMessage(newStartTime, endTime));
+    handleChangeFormContent('startTime', newStartTime);
+    setTimeError(getTimeErrorMessage(newStartTime, eventForm.endTime));
   };
 
   const handleEndTimeChange = (e: ChangeEvent<HTMLInputElement>) => {
     const newEndTime = e.target.value;
-    setEndTime(newEndTime);
-    setTimeError(getTimeErrorMessage(startTime, newEndTime));
+
+    handleChangeFormContent('endTime', newEndTime);
+    setTimeError(getTimeErrorMessage(eventForm.startTime, newEndTime));
   };
 
   const resetForm = () => {
-    setTitle('');
-    setDate('');
-    setStartTime('');
-    setEndTime('');
-    setDescription('');
-    setLocation('');
-    setCategory('');
+    setEventForm(initialEventValue);
     setIsRepeating(false);
-    setRepeatType('none');
-    setRepeatInterval(1);
-    setRepeatEndDate('');
-    setNotificationTime(10);
-  };
-
-  const editEvent = (event: Event) => {
-    setEditingEvent(event);
-    setTitle(event.title);
-    setDate(event.date);
-    setStartTime(event.startTime);
-    setEndTime(event.endTime);
-    setDescription(event.description);
-    setLocation(event.location);
-    setCategory(event.category);
-    setIsRepeating(event.repeat.type !== 'none');
-    setRepeatType(event.repeat.type);
-    setRepeatInterval(event.repeat.interval);
-    setRepeatEndDate(event.repeat.endDate || '');
-    setNotificationTime(event.notificationTime);
   };
 
   return {
-    title,
-    setTitle,
-    date,
-    setDate,
-    startTime,
-    setStartTime,
-    endTime,
-    setEndTime,
-    description,
-    setDescription,
-    location,
-    setLocation,
-    category,
-    setCategory,
+    eventForm,
+    setEventForm,
+    handleChangeFormContent,
+    handleChangeFormRepeat,
     isRepeating,
     setIsRepeating,
-    repeatType,
-    setRepeatType,
-    repeatInterval,
-    setRepeatInterval,
-    repeatEndDate,
-    setRepeatEndDate,
-    notificationTime,
-    setNotificationTime,
     startTimeError,
     endTimeError,
-    editingEvent,
-    setEditingEvent,
     handleStartTimeChange,
     handleEndTimeChange,
     resetForm,
-    editEvent,
   };
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,5 @@
 import { ChakraProvider } from '@chakra-ui/react';
+import { OverlayProvider } from 'overlay-kit';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 
@@ -7,7 +8,9 @@ import App from './App.tsx';
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ChakraProvider>
-      <App />
+      <OverlayProvider>
+        <App />
+      </OverlayProvider>
     </ChakraProvider>
   </React.StrictMode>
 );

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,16 +1,27 @@
 import { setupServer } from 'msw/node';
 import '@testing-library/jest-dom';
 
-import { handlers } from './__mocks__/handlers';
+// import { handlers } from './__mocks__/handlers';
+import { setupHandler } from './__mocks__/handlersUtils';
 
 /* msw */
-export const server = setupServer(...handlers);
+export const server = setupServer();
+let setupHandlerEvents = setupHandler();
 
 beforeAll(() => {
   server.listen();
 });
 
 beforeEach(() => {
+  setupHandlerEvents.resetInitState();
+  const handlers = [
+    setupHandlerEvents.setupMockHandlerRead(),
+    setupHandlerEvents.setupMockHandlerDeletion(),
+    setupHandlerEvents.setupMockHandlerCreation(),
+    setupHandlerEvents.setupMockHandlerUpdating(),
+  ];
+
+  server.resetHandlers(...handlers);
   expect.hasAssertions();
 });
 

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -87,8 +87,14 @@ export function formatMonth(date: Date): string {
 /**
  * 주어진 날짜가 특정 범위 내에 있는지 확인합니다.
  */
+const stripTime = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate());
+
 export function isDateInRange(date: Date, rangeStart: Date, rangeEnd: Date): boolean {
-  return date >= rangeStart && date <= rangeEnd;
+  const normalizedDate = stripTime(date);
+  const normalizedStart = stripTime(rangeStart);
+  const normalizedEnd = stripTime(rangeEnd);
+
+  return normalizedDate >= normalizedStart && normalizedDate <= normalizedEnd;
 }
 
 export function fillZero(value: number, size = 2) {


### PR DESCRIPTION
# HARD

## 7주차 과제 체크포인트

### 기본과제

- [x] 총 11개의 파일, 115개의 단위 테스트를 무사히 작성하고 통과시킨다.

#### 질문

> Q. handlersUtils에 남긴 질문에 답변해주세요.

`
각각의 테스트를 실행하기 전 beforeEach사이클을 이용했습니다.
`
`
beforeEach의 콜백함수로는 event json파일의 원본을 가져와 초기화 시켜주는 작업을 진행했습니다.
`

<hr />

> Q. 테스트를 독립적으로 구동시키기 위해 작성했던 설정들을 소개해주세요.

`
handlerUtils에 setupHandler함수를 클로저로 구현했습니다.
`
![image](https://github.com/user-attachments/assets/0ce681ab-b345-402f-b1db-a7e54f78946a)

setupTest.ts파일 전역에서 setupHandler함수를 변수에 할당 시켜줬습니다.


`
beforeEach가 실행될 때마다 핸들러들을 리셋하고, 
변수에 저장된 event State를 event.json으로 초기화 시켜주는 작업을 진행했습니다.
이렇게해서 테스트들을 한번에 병렬적으로 실행해도, 각각 독립적으로 돌아갈 수 있게 구현했습니다.
`

![image](https://github.com/user-attachments/assets/8f44fe5f-2cfe-43fe-a578-778275849d31)


### 심화 과제

- [x] App 컴포넌트 적절한 단위의 컴포넌트, 훅, 유틸 함수로 분리했는가?
- [ ] 해당 모듈들에 대한 적절한 테스트를 2개 이상 작성했는가?

<hr />

## 궁금한 점 || 리뷰 받고 싶은 내용

- medium.integration.spec.ts 작성 중, 한 테스트당 코드라인이 과도하게 길어지는데 좋게 작성 된 것인지 모르겠습니다. 

- setupTest.ts파일에 handler.ts를 적용시키지 않고, handlerUtils.ts를 적용시켰습니다.(더 나은 버전이라고 생각했습니다)
 이렇게 handler와 setupTest에 before과 after사이클을 작성 해줬는데, 이런 방식이 올바른 방식일까요?
아니면 각각의 파일에서 before과 after를 적어주는게 맞을까요?

- handlerUtils를 클로저로 구현했는데 괜찮은 방식일까요? 테스트를 계속 실행하다보면 클로저에 할당되는 변수가 계속 생길텐데 메모리 누수는 없을까요?

<hr />
## 과제를 수행하면서 느낀점

### 과제 시작 전 생각
일단 하드 시작. 잘 할 수 있을 지
시간 안될 것 같으면 미디움으로 내리던가..

### 과제 제출 후 생각
생각보다 아예 못할정도는 아니었던 것 같다.
맨땅에서부터 정말 많은 걸 배웠다. 일주일 굉장히 알찬 시간.

아직까지 테스트를 작성하는 이유를 크게 못 느끼고 있다.
느낀바론 테스트코드 작성 행위 자체가 굉장히 불편한게 많음을 느꼈다. 
UI를 볼 수 없으니 답답함이 많이 느껴짐.
그럼에도 많은 사람들이 작성하는 이유가 있겠지 싶다.
조금 더 적응하면 달라지겠지..

## 기타

### 과제 난이도
이지1/5
미디움3/5
하드 4.5/5